### PR TITLE
Fix marketplace schema and bump to v0.1.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,18 @@
   },
   "metadata": {
     "description": "CaldiaWorks plugin marketplace",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "pluginRoot": "./"
   },
   "plugins": [
     {
       "name": "caldiaworks",
-      "source": "caldiaworks",
-      "skills": ["ears", "usdm"]
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/ears",
+        "./skills/usdm"
+      ]
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "caldiaworks-marketplace",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "CaldiaWorks plugin marketplace",
   "skills": [
     "./skills/ears",


### PR DESCRIPTION
## Summary
- Fix `source` and `skills` format in `marketplace.json` to match official plugin schema
- Bump version to 0.1.3

## Changes
- `source`: `"caldiaworks"` → `"./"`
- `skills`: `["ears", "usdm"]` → `["./skills/ears", "./skills/usdm"]`
- Added `strict: false`