### PR TITLE
Set strict mode and update gitignore

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "caldiaworks",
       "source": "./",
-      "strict": false,
+      "strict": true,
       "skills": [
         "./skills/ears",
         "./skills/usdm"

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 
 CLAUDE.md
 tmp**
+
+.agent/
+.agents/
+skills-lock.json


### PR DESCRIPTION
## Summary
- Set `strict: true` in marketplace entry to resolve conflicting manifests
- Add agent directories and lock file to gitignore