### PR TITLE
Add requirements-docx skill for USDM/EARS to Word conversion

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "CaldiaWorks plugin marketplace",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "pluginRoot": "./"
   },
   "plugins": [
@@ -15,7 +15,8 @@
       "strict": true,
       "skills": [
         "./skills/ears",
-        "./skills/usdm"
+        "./skills/usdm",
+        "./skills/requirements-docx"
       ]
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,9 +1,10 @@
 {
   "name": "caldiaworks-marketplace",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "CaldiaWorks plugin marketplace",
   "skills": [
     "./skills/ears",
-    "./skills/usdm"
+    "./skills/usdm",
+    "./skills/requirements-docx"
   ]
 }

--- a/REQ-DOC-20260221-001-requirements-docx.md
+++ b/REQ-DOC-20260221-001-requirements-docx.md
@@ -1,0 +1,269 @@
+# Requirements Document: 要件定義書Word形式変換スキル
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| Document ID | REQ-DOC-20260221-001-requirements-docx |
+| Version | 0.1.0 |
+| Status | Draft |
+| Author | — |
+| Created | 2026-02-21 |
+| Last Updated | 2026-02-21 |
+
+## Ticket References
+
+| Source | ID | Title |
+|--------|-----|-------|
+| GitHub Issue | #3 | 要件定義書のWord形式(.docx)変換スキルの追加 |
+
+## Stakeholders
+
+| Role | Name / Team | Concern |
+|------|------------|---------|
+| Requirements Author | Skill User | Markdown要件定義書からWord文書を迅速に生成したい |
+| Client | Document Recipient | 整形されたWord文書で要件定義書を受領したい |
+| Skill Developer | CaldiaWorks | 既存スキル（docx, USDM, EARS）との一貫した連携を維持したい |
+
+## Glossary
+
+| Term | Definition |
+|------|-----------|
+| USDM | Universal Specification Describing Manner — 要件をRequirement → Reason → Description → Specification階層で構造化する手法 |
+| EARS | Easy Approach to Requirements Syntax — WHEN/WHILE/IF/THEN/WHEREパターンによる曖昧性排除記法 |
+| docx skill | Claude Codeの既存スキル。Word文書（.docx）の作成・編集機能を提供する |
+| Traceability Matrix | 要件（REQ）と仕様（SPEC）の対応関係を示す追跡表 |
+
+---
+
+## Requirements
+
+### REQ-001: 要件定義書のWord形式変換
+
+**Reason**: クライアントへの要件定義書提出にはWord形式が求められるが、現在のUSDM/EARSスキルはMarkdown形式のみ出力する。手動でのフォーマット変換作業を自動化することで、要件定義プロセスの提出工程を効率化する必要がある。
+
+**Description**: USDMスキルおよびEARSスキルが出力するMarkdown形式の要件定義書を、クライアント提出用のWord文書（.docx）に変換するClaude Codeスキル。対象入力はUSDMテンプレート（`skills/usdm/templates/usdm-requirements.md`）に準拠したMarkdownファイルとする。
+
+---
+
+#### REQ-001-1: 入力Markdownの受け付け
+
+**Reason**: Word変換を行うには、USDM/EARS形式のMarkdownファイルを入力として受け付ける必要がある。
+
+**Description**: USDMスキルが出力するテンプレート構造に準拠したMarkdownファイルを入力として受け付ける。EARS記法を含む仕様も入力対象とする。
+
+##### SPEC-001: 入力ファイルパスの指定
+
+WHEN the user specifies a Markdown file path, the skill shall read the file content and proceed with conversion.
+
+##### SPEC-002: USDMテンプレート準拠ファイルの受け付け
+
+The skill shall accept Markdown files that follow the USDM template structure defined in `skills/usdm/templates/usdm-requirements.md`.
+
+##### SPEC-003: EARS記法を含むファイルの受け付け
+
+The skill shall accept Markdown files containing EARS-formatted specifications with WHEN, WHILE, IF, THEN, and WHERE keywords.
+
+---
+
+#### REQ-001-2: USDM階層構造の解析
+
+**Reason**: Markdownの見出しレベルやテキストパターンからUSDM階層（REQ → Reason → Description → SPEC）を正確に識別し、Word文書に変換可能な構造データとして保持する必要がある。
+
+**Description**: Markdown見出しレベル、太字プレフィックス、テーブル構造からUSDM要素を解析する。
+
+##### SPEC-004: 要件要素の識別
+
+The skill shall identify requirement elements from Markdown headings matching the pattern `### REQ-{NNN}: {Title}` for top-level requirements and `#### REQ-{NNN}-{N}: {Title}` for sub-requirements.
+
+##### SPEC-005: 仕様要素の識別
+
+The skill shall identify specification elements from Markdown headings matching the pattern `#### SPEC-{NNN}: {Title}` or `##### SPEC-{NNN}: {Title}`.
+
+##### SPEC-006: Reason/Descriptionフィールドの抽出
+
+The skill shall extract Reason and Description fields from bold-prefixed paragraphs (`**Reason**:` and `**Description**:`).
+
+##### SPEC-007: メタデータの抽出
+
+The skill shall extract metadata fields (Document ID, Version, Status, Author, Created, Last Updated) from the Metadata table in the Markdown document.
+
+##### SPEC-008: トレーサビリティマトリクスの抽出
+
+The skill shall extract the Traceability Matrix from the Markdown table containing columns: Source, REQ, SPEC, and Verification Method.
+
+---
+
+#### REQ-001-3: Word文書の構造生成
+
+**Reason**: クライアントが読みやすく、文書管理に適した書式で要件定義書を受領できるようにするため、USDM階層をWord文書の見出し・段落・表に変換する必要がある。
+
+**Description**: 解析したUSDM構造をWord文書の各要素（表紙、目次、見出し、段落、表）に変換する。既存のdocxスキルを使用して文書を生成する。
+
+---
+
+##### REQ-001-3-1: 表紙の生成
+
+**Reason**: クライアント提出用文書には、文書の識別と管理のために表紙が必要である。
+
+**Description**: Markdownメタデータセクションの情報を使用して表紙ページを生成する。
+
+###### SPEC-009: 表紙の内容
+
+The skill shall generate a cover page containing: document title, Document ID, Version, Status, Author, Created date, and Last Updated date.
+
+###### SPEC-010: 表紙後の改ページ
+
+The skill shall insert a page break after the cover page.
+
+---
+
+##### REQ-001-3-2: 目次の生成
+
+**Reason**: 文書内のナビゲーションを容易にするため、見出しに基づく目次が必要である。
+
+**Description**: Word文書の見出しスタイルに基づく目次を表紙の次に挿入する。
+
+###### SPEC-011: 目次の挿入
+
+The skill shall insert a table of contents after the cover page, referencing Heading 1 through Heading 4 styles.
+
+###### SPEC-012: 目次後の改ページ
+
+The skill shall insert a page break after the table of contents.
+
+---
+
+##### REQ-001-3-3: 見出しレベルのマッピング
+
+**Reason**: USDM階層の各レベルを視覚的に区別するため、Word見出しレベルへの一貫した対応付けが必要である。
+
+**Description**: USDM要素とWord見出しスタイルの対応関係を定義する。
+
+###### SPEC-013: トップレベル要件の見出し
+
+The skill shall map top-level requirements (REQ-NNN) to Heading 2 style.
+
+###### SPEC-014: サブ要件の見出し
+
+The skill shall map sub-requirements (REQ-NNN-N) to Heading 3 style.
+
+###### SPEC-015: 仕様の見出し
+
+The skill shall map specifications (SPEC-NNN) to Heading 4 style.
+
+###### SPEC-016: Reasonフィールドの表示
+
+The skill shall render Reason fields as paragraphs with bold "Reason:" prefix.
+
+###### SPEC-017: Descriptionフィールドの表示
+
+The skill shall render Description fields as paragraphs with bold "Description:" prefix.
+
+---
+
+##### REQ-001-3-4: EARSキーワードの視覚的強調
+
+**Reason**: EARS記法のキーワードは仕様の構造的意味を持つ重要な要素であり、文書内で視覚的に識別できる必要がある。
+
+**Description**: EARS記法のキーワード（WHEN, WHILE, IF, THEN, WHERE）を仕様テキスト内で太字表示する。
+
+###### SPEC-018: EARSキーワードの太字表示
+
+The skill shall render EARS keywords (WHEN, WHILE, IF, THEN, WHERE) in bold within specification text.
+
+---
+
+##### REQ-001-3-5: トレーサビリティマトリクスの出力
+
+**Reason**: 要件と仕様の追跡可能性を文書内で一覧として確認できるようにするため、マトリクスを表形式で出力する必要がある。
+
+**Description**: 抽出したトレーサビリティマトリクスをWord表として生成する。
+
+###### SPEC-019: マトリクス表の生成
+
+The skill shall render the Traceability Matrix as a Word table with columns: Source, REQ, SPEC, and Verification Method.
+
+###### SPEC-020: ヘッダー行の書式
+
+The skill shall apply bold text and shaded background to the header row of the Traceability Matrix table.
+
+---
+
+#### REQ-001-4: ファイル出力
+
+**Reason**: 生成した文書を.docx形式で保存し、クライアントに提出可能な状態にする必要がある。
+
+**Description**: 生成したWord文書を.docxファイルとしてカレントディレクトリに保存する。
+
+##### SPEC-021: 出力先
+
+The skill shall save the generated document as a .docx file in the current working directory.
+
+##### SPEC-022: ファイル命名規則
+
+The skill shall name the output file using the Document ID from the metadata (e.g., `REQ-DOC-20260221-001-requirements-docx.docx`).
+
+---
+
+### REQ-002: docxスキルとの連携
+
+**Reason**: Word文書の生成機能をゼロから実装するのではなく、既存のdocxスキルが提供する文書作成機能を活用することで、開発効率を確保し重複実装を回避する必要がある。
+
+**Description**: Claude Codeの既存スキルであるdocxスキルを使用して、Word文書の生成・書式設定を行う。スキルのSKILL.md内でdocxスキルの呼び出し手順を定義する。
+
+#### SPEC-023: docxスキルへの委譲
+
+The skill shall delegate Word document creation and formatting to the existing `docx` Claude Code skill.
+
+#### SPEC-024: 文書構造の受け渡し
+
+The skill shall pass document structure (headings, paragraphs, tables, page breaks) to the docx skill in the format accepted by that skill.
+
+---
+
+### REQ-003: Markdown入力の不備への対応
+
+**Reason**: 入力Markdownが必ずしもUSDMテンプレートに完全準拠しているとは限らないため、不備がある場合にユーザーに通知して対応を求める必要がある。
+
+**Description**: 入力MarkdownのUSDMテンプレート準拠性を検証し、不足項目をユーザーに報告する。
+
+#### SPEC-025: メタデータ欠落時の通知
+
+IF the input Markdown is missing required metadata fields (Document ID, Version, Author), THEN the skill shall notify the user of the missing fields and prompt for input before proceeding.
+
+#### SPEC-026: USDM構造不備時の通知
+
+IF the input Markdown contains requirements without at least one specification, THEN the skill shall warn the user and list the affected requirement IDs.
+
+---
+
+## Traceability Matrix
+
+| Source | REQ | SPEC | Verification Method |
+|--------|-----|------|-------------------|
+| Issue #3 — 入力 | REQ-001-1 | SPEC-001, SPEC-002, SPEC-003 | Test |
+| Issue #3 — 入力 | REQ-001-2 | SPEC-004, SPEC-005, SPEC-006, SPEC-007, SPEC-008 | Test |
+| Issue #3 — 表紙 | REQ-001-3-1 | SPEC-009, SPEC-010 | Inspection |
+| Issue #3 — 目次 | REQ-001-3-2 | SPEC-011, SPEC-012 | Inspection |
+| Issue #3 — 見出しマッピング | REQ-001-3-3 | SPEC-013, SPEC-014, SPEC-015, SPEC-016, SPEC-017 | Inspection |
+| Issue #3 — EARSキーワード | REQ-001-3-4 | SPEC-018 | Inspection |
+| Issue #3 — トレーサビリティ | REQ-001-3-5 | SPEC-019, SPEC-020 | Inspection |
+| Issue #3 — 出力 | REQ-001-4 | SPEC-021, SPEC-022 | Test |
+| Issue #3 — 非機能要件 | REQ-002 | SPEC-023, SPEC-024 | Test |
+| Hidden Verb Discovery | REQ-003 | SPEC-025, SPEC-026 | Test |
+
+## Open Questions
+
+| # | Question | Raised By | Status |
+|---|----------|-----------|--------|
+| 1 | 表紙のレイアウト（ロゴ配置、フォント指定等）の詳細仕様は別途定義が必要か？ | Analysis | Open |
+| 2 | Stakeholders/Glossary等のメタデータセクションもWord文書に含めるか？ | Analysis | Open |
+| 3 | テンプレートカスタマイズ機能（Issue #3で将来対応とされた）のスコープと優先度は？ | Issue #3 | Open |
+| 4 | 変更履歴（Change History）セクションもWord文書に含めるか？ | Analysis | Open |
+
+## Change History
+
+| Version | Date | Author | Description |
+|---------|------|--------|-------------|
+| 0.1.0 | 2026-02-21 | — | Initial draft from Issue #3 |

--- a/skills/requirements-docx/.claude-plugin/plugin.json
+++ b/skills/requirements-docx/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "requirements-docx",
+  "version": "0.1.0",
+  "description": "Convert USDM/EARS requirements documents to professionally formatted Word documents.",
+  "skills": ["."]
+}

--- a/skills/requirements-docx/SKILL.md
+++ b/skills/requirements-docx/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: requirements-docx
+version: 0.1.0
+description: >-
+  Convert USDM/EARS requirements documents from Markdown to professionally
+  formatted Word (.docx) files for client submission. Generates cover pages,
+  table of contents, headers/footers, and styled requirement hierarchies.
+  Leverages the docx skill for Word file generation.
+  Use when: "export requirements to Word", "requirements to docx", "USDM to Word",
+  "convert requirements document", "要件書をWord出力", "要件定義書のdocx変換",
+  "Word形式で要件書を作成", "要件定義書をWordに変換".
+---
+
+# USDM/EARS Requirements Document — Word Export
+
+You are a requirements document formatting specialist. Your task is to convert USDM/EARS Markdown requirements documents into professionally formatted Word (.docx) files suitable for client submission.
+
+**Important**: You do NOT create or modify requirements. That is the role of the `usdm` and `ears` skills. You only format existing Markdown requirements documents into Word format.
+
+## Input
+
+Accept Markdown files that follow the USDM template structure (`skills/usdm/templates/usdm-requirements.md`). The input file contains:
+
+- **Metadata table**: Document ID, Version, Status, Author, dates
+- **Ticket References table**
+- **Stakeholders table**
+- **Glossary table**
+- **Requirements section**: REQ-NNN hierarchy with Reason, Description, and SPEC-NNN specifications
+- **Traceability Matrix table**
+- **Open Questions table**
+- **Change History table**
+
+EARS-formatted specifications (containing WHEN, WHILE, IF, THEN, WHERE keywords) are supported within the requirements section.
+
+## Workflow
+
+### Step 1: Parse and Validate Input
+
+1. Read the source Markdown file specified by the user.
+2. Extract metadata fields from the Metadata table:
+   - Document ID, Version, Status, Author, Created, Last Updated
+3. Extract all requirements (headings matching `### REQ-{NNN}: {Title}` or `#### REQ-{NNN}-{N}: {Title}`) and their Reason/Description fields (bold-prefixed paragraphs `**Reason**:` and `**Description**:`).
+4. Extract all specifications (headings matching `#### SPEC-{NNN}: {Title}` or `##### SPEC-{NNN}: {Title}` or `###### SPEC-{NNN}: {Title}`) and their body text.
+5. Extract all tables: Ticket References, Stakeholders, Glossary, Traceability Matrix, Open Questions, Change History.
+6. **Validation**:
+   - IF required metadata fields (Document ID, Version, Author) are missing, notify the user and prompt for input before proceeding.
+   - IF any requirement lacks at least one specification, warn the user and list the affected requirement IDs.
+7. Report parsing results to the user (counts of REQ, SPEC, tables found).
+
+### Step 2: Plan Document Layout
+
+Determine the document structure:
+
+1. **Section 1 — Cover Page**: Title, logo placeholder, metadata table, confidentiality notice
+2. **Section 2 — Table of Contents**: Auto-generated from heading styles
+3. **Section 3 — Main Content**:
+   - Stakeholders table
+   - Glossary table
+   - Requirements (full hierarchy with Reason/Description/Specifications)
+   - Traceability Matrix table
+   - Open Questions table
+   - Change History table
+
+Confirm the layout with the user before proceeding.
+
+### Step 3: Read docx-js Reference (MANDATORY)
+
+**You MUST read the docx skill's `docx-js.md` reference file completely before generating any code.** This file contains critical syntax, formatting rules, and common pitfalls for the docx-js library.
+
+Read the file at: `~/.agents/skills/docx/docx-js.md`
+
+### Step 4: Generate and Execute docx-js Script
+
+1. Read the style definitions from `references/docx-style-definitions.md` in this skill's directory.
+2. Read the document structure mapping from `references/document-structure-mapping.md` in this skill's directory.
+3. Generate a JavaScript file that uses the docx-js library to create the Word document.
+4. The generated script must implement:
+   - Cover page with logo placeholder, title, metadata table, and confidentiality notice
+   - Table of contents referencing Heading 1 through Heading 4
+   - Page break after cover page and after table of contents
+   - All content sections with proper heading levels
+   - EARS keyword bold formatting in specification text
+   - All tables with header row styling
+   - Headers and footers
+5. Execute the script with `node` to produce the .docx file.
+
+### Step 5: Output and Verification
+
+1. Save the .docx file in the current working directory.
+2. Name the file using the Document ID from metadata (e.g., `REQ-DOC-20260221-001-requirements-docx.docx`). If no Document ID is found, use the input filename with `.docx` extension.
+3. Report the output file path and size to the user.
+4. Suggest visual verification:
+   ```bash
+   soffice --headless --convert-to pdf <output.docx>
+   pdftoppm -jpeg -r 150 <output.pdf> page
+   ```
+
+## Document Structure Mapping
+
+### Heading Level Mapping
+
+| Markdown Element | Word Style | Description |
+|-----------------|------------|-------------|
+| `# Document Title` | Cover page title (28pt bold, centered) | Extracted for cover page, not repeated in body |
+| `## Section Name` | Heading 1 | Top-level sections (Stakeholders, Glossary, Requirements, etc.) |
+| `### REQ-NNN: Title` | Heading 2 | Top-level requirements |
+| `#### REQ-NNN-N: Title` | Heading 3 | Sub-requirements |
+| `#### SPEC-NNN: Title` | Heading 3 | Specifications directly under a top-level requirement |
+| `##### SPEC-NNN: Title` | Heading 4 | Specifications under sub-requirements |
+| `##### REQ-NNN-N-N: Title` | Heading 4 | Sub-sub-requirements |
+| `###### SPEC-NNN: Title` | Heading 4 | Specifications under sub-sub-requirements |
+
+### Field Formatting
+
+| Field | Format |
+|-------|--------|
+| `**Reason**: text` | Bold "Reason:" label followed by normal-weight text on the same line |
+| `**Description**: text` | Bold "Description:" label followed by normal-weight text on the same line |
+
+### EARS Keyword Formatting
+
+Within specification body text (text under SPEC-NNN headings), apply bold formatting to EARS keywords:
+
+- Keywords: **WHEN**, **WHILE**, **IF**, **THEN**, **WHERE**
+- Split the specification text into TextRun segments at keyword boundaries
+- Apply bold to keyword TextRuns, normal weight to surrounding text
+- Keywords are identified by the regex `\b(WHEN|WHILE|IF|THEN|WHERE)\b` in uppercase
+- "shall" and "may" keywords also receive bold formatting
+
+Example transformation:
+```
+Input:  "WHEN the user submits valid credentials, the system shall authenticate the user."
+Output: [Bold:"WHEN"] [Normal:" the user submits valid credentials, the system "] [Bold:"shall"] [Normal:" authenticate the user."]
+```
+
+### Table Formatting
+
+All tables share common formatting:
+- Header row: bold text + light blue background (`#D5E8F0`)
+- Borders: light gray (`#CCCCCC`), single style
+- Cell padding via table-level margins
+
+| Table | Columns | Notes |
+|-------|---------|-------|
+| Metadata | 2 (Field, Value) | First column bold |
+| Ticket References | 3 (Source, ID, Title) | Standard |
+| Stakeholders | 3 (Role, Name/Team, Concern) | Standard |
+| Glossary | 2 (Term, Definition) | Term column bold |
+| Traceability Matrix | 4 (Source, REQ, SPEC, Verification Method) | Standard |
+| Open Questions | 4 (#, Question, Raised By, Status) | Standard |
+| Change History | 4 (Version, Date, Author, Description) | Standard |
+
+### Cover Page Layout
+
+```
+┌─────────────────────────────────┐
+│                                 │
+│     [Logo Placeholder Area]     │  ← Gray bordered rectangle, centered
+│     (Company Logo)              │
+│                                 │
+│                                 │
+│     ┌───────────────────────┐   │
+│     │   Document Title      │   │  ← 28pt bold, centered
+│     │   (from H1 heading)   │   │
+│     └───────────────────────┘   │
+│                                 │
+│     ┌───────────────────────┐   │
+│     │ Document ID │ value   │   │  ← Metadata table
+│     │ Version     │ value   │   │
+│     │ Status      │ value   │   │
+│     │ Author      │ value   │   │
+│     │ Created     │ value   │   │
+│     │ Last Updated│ value   │   │
+│     └───────────────────────┘   │
+│                                 │
+│     CONFIDENTIAL                │  ← Confidentiality notice, centered
+│                                 │
+└─────────────────────────────────┘
+```
+
+### Headers and Footers (Main Content Section)
+
+- **Header**: Document ID (left-aligned) + Document title (right-aligned)
+- **Footer**: "Page X of Y" (center-aligned)
+
+## Style Reference
+
+Apply styles from `references/docx-style-definitions.md`. Key points:
+- Font: Arial (ascii/hAnsi) + Yu Gothic (eastAsia) for Japanese support
+- Body text: 11pt (size: 22 in half-points)
+- Use heading style overrides with proper `outlineLevel` for TOC compatibility
+- Table shading: always use `ShadingType.CLEAR` to avoid black background issues
+
+## References
+
+- `references/document-structure-mapping.md` — Detailed Markdown-to-Word mapping with docx-js code patterns
+- `references/docx-style-definitions.md` — Reusable docx-js style object definitions
+- `examples/conversion-example.md` — Before/after conversion walkthrough

--- a/skills/requirements-docx/examples/conversion-example.md
+++ b/skills/requirements-docx/examples/conversion-example.md
@@ -1,0 +1,154 @@
+# Conversion Example: USDM Markdown to Word
+
+## Input (Markdown excerpt)
+
+```markdown
+# Requirements Document: User Authentication
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| Document ID | REQ-DOC-20260215-001-user-auth |
+| Version | 0.1.0 |
+| Status | Draft |
+| Author | John Smith |
+| Created | 2026-02-15 |
+| Last Updated | 2026-02-15 |
+
+## Stakeholders
+
+| Role | Name / Team | Concern |
+|------|------------|---------|
+| Product Owner | Jane Doe | Secure and fast login experience |
+
+## Glossary
+
+| Term | Definition |
+|------|-----------|
+| USDM | Universal Specification Describing Manner |
+
+## Requirements
+
+### REQ-001: User Authentication
+
+**Reason**: Users must prove their identity before accessing protected resources.
+
+**Description**: The login feature allows registered users to authenticate using email and password.
+
+#### REQ-001-1: Credential Input and Validation
+
+**Reason**: The system needs to collect user credentials in a structured way.
+
+**Description**: The login form UI and client-side input handling.
+
+##### SPEC-001: Login Form
+
+The system shall provide a login form that accepts an email address and a password.
+
+##### SPEC-002: Authentication Processing
+
+WHEN the user submits valid credentials, the system shall authenticate the user and create a session within 500 ms.
+
+### REQ-002: Authentication Security
+
+**Reason**: Credentials must be protected from interception and brute-force attacks.
+
+**Description**: Security measures applied to the authentication process.
+
+#### SPEC-003: Account Lockout
+
+IF the user fails authentication 5 consecutive times, THEN the system shall lock the account for 15 minutes.
+
+## Traceability Matrix
+
+| Source | REQ | SPEC | Verification Method |
+|--------|-----|------|-------------------|
+| Requirement | REQ-001 | SPEC-001, SPEC-002 | Test |
+| Requirement | REQ-002 | SPEC-003 | Test |
+
+## Change History
+
+| Version | Date | Author | Description |
+|---------|------|--------|-------------|
+| 0.1.0 | 2026-02-15 | John Smith | Initial draft |
+```
+
+## Output Word Document Structure
+
+### Page 1: Cover Page
+
+- **Logo placeholder**: Gray-bordered rectangle at top center
+- **Title**: "Requirements Document: User Authentication" — 28pt bold, centered
+- **Metadata table**: 2-column table with Document ID, Version, Status, Author, dates
+- **Confidentiality**: "CONFIDENTIAL" at bottom center
+
+### Page 2: Table of Contents
+
+- Auto-generated TOC referencing:
+  - Heading 1: Stakeholders, Glossary, Requirements, Traceability Matrix, Change History
+  - Heading 2: REQ-001, REQ-002
+  - Heading 3: REQ-001-1, SPEC-003
+  - Heading 4: SPEC-001, SPEC-002
+
+### Page 3+: Main Content
+
+#### Heading Level Hierarchy
+
+```
+[Heading 1] Stakeholders
+  └─ Stakeholders table (header: light blue background)
+
+[Heading 1] Glossary
+  └─ Glossary table (Term column bold)
+
+[Heading 1] Requirements
+
+  [Heading 2] REQ-001: User Authentication
+    Reason: Users must prove their identity...
+    Description: The login feature allows...
+
+    [Heading 3] REQ-001-1: Credential Input and Validation
+      Reason: The system needs to collect...
+      Description: The login form UI and...
+
+      [Heading 4] SPEC-001: Login Form
+        The system **shall** provide a login form that accepts an email address and a password.
+
+      [Heading 4] SPEC-002: Authentication Processing
+        **WHEN** the user submits valid credentials, the system **shall** authenticate the user and create a session within 500 ms.
+
+  [Heading 2] REQ-002: Authentication Security
+    Reason: Credentials must be protected...
+    Description: Security measures applied...
+
+    [Heading 3] SPEC-003: Account Lockout
+      **IF** the user fails authentication 5 consecutive times, **THEN** the system **shall** lock the account for 15 minutes.
+
+[Heading 1] Traceability Matrix
+  └─ 4-column table
+
+[Heading 1] Change History
+  └─ 4-column table
+```
+
+#### EARS Keyword Formatting Detail
+
+In SPEC-002:
+- "**WHEN**" → Bold TextRun
+- " the user submits valid credentials, the system " → Normal TextRun
+- "**shall**" → Bold TextRun
+- " authenticate the user and create a session within 500 ms." → Normal TextRun
+
+In SPEC-003:
+- "**IF**" → Bold TextRun
+- " the user fails authentication 5 consecutive times, " → Normal TextRun
+- "**THEN**" → Bold TextRun
+- " the system " → Normal TextRun
+- "**shall**" → Bold TextRun
+- " lock the account for 15 minutes." → Normal TextRun
+
+### Headers and Footers (Main Content)
+
+- **Header**: "REQ-DOC-20260215-001-user-auth" (left) + "User Authentication" (right)
+- **Footer**: "Page X of Y" (center)

--- a/skills/requirements-docx/references/document-structure-mapping.md
+++ b/skills/requirements-docx/references/document-structure-mapping.md
@@ -1,0 +1,336 @@
+# Document Structure Mapping: USDM Markdown to Word
+
+This reference defines the mapping from USDM Markdown elements to Word document elements using docx-js code patterns.
+
+## Cover Page (Section 1)
+
+The cover page is a separate Word section with no headers/footers.
+
+### Logo Placeholder
+
+A gray-bordered rectangle area for company logo placement.
+
+```javascript
+// Logo placeholder - gray bordered empty area
+new Paragraph({
+  alignment: AlignmentType.CENTER,
+  spacing: { before: 2400, after: 400 },
+  border: {
+    top: { style: BorderStyle.SINGLE, size: 1, color: "999999", space: 8 },
+    bottom: { style: BorderStyle.SINGLE, size: 1, color: "999999", space: 8 },
+    left: { style: BorderStyle.SINGLE, size: 1, color: "999999", space: 8 },
+    right: { style: BorderStyle.SINGLE, size: 1, color: "999999", space: 8 }
+  },
+  children: [
+    new TextRun({ text: "Company Logo", color: "999999", size: 20, italics: true })
+  ]
+})
+```
+
+### Document Title
+
+Extract from the H1 heading (`# Document Title`).
+
+```javascript
+new Paragraph({
+  alignment: AlignmentType.CENTER,
+  spacing: { before: 1200, after: 600 },
+  children: [
+    new TextRun({
+      text: documentTitle,
+      bold: true,
+      size: 56, // 28pt
+      font: { ascii: "Arial", eastAsia: "Yu Gothic", hAnsi: "Arial" }
+    })
+  ]
+})
+```
+
+### Metadata Table (Cover Page)
+
+Extract fields from the `## Metadata` table. Render as a 2-column table.
+
+```javascript
+const metadataRows = [
+  ["Document ID", metadata.documentId],
+  ["Version", metadata.version],
+  ["Status", metadata.status],
+  ["Author", metadata.author],
+  ["Created", metadata.created],
+  ["Last Updated", metadata.lastUpdated]
+];
+
+new Table({
+  columnWidths: [3000, 5000],
+  margins: { top: 80, bottom: 80, left: 120, right: 120 },
+  rows: metadataRows.map(([field, value]) =>
+    new TableRow({
+      children: [
+        new TableCell({
+          borders: cellBorders,
+          width: { size: 3000, type: WidthType.DXA },
+          children: [new Paragraph({
+            children: [new TextRun({ text: field, bold: true, size: 22 })]
+          })]
+        }),
+        new TableCell({
+          borders: cellBorders,
+          width: { size: 5000, type: WidthType.DXA },
+          children: [new Paragraph({
+            children: [new TextRun({ text: value, size: 22 })]
+          })]
+        })
+      ]
+    })
+  )
+})
+```
+
+### Confidentiality Notice
+
+```javascript
+new Paragraph({
+  alignment: AlignmentType.CENTER,
+  spacing: { before: 1200 },
+  children: [
+    new TextRun({ text: "CONFIDENTIAL", bold: true, size: 24, color: "666666" })
+  ]
+})
+```
+
+### Page Break After Cover
+
+```javascript
+new Paragraph({ children: [new PageBreak()] })
+```
+
+## Table of Contents (Section 2)
+
+Insert after the cover page. References heading levels 1-4.
+
+```javascript
+new TableOfContents("Table of Contents", {
+  hyperlink: true,
+  headingStyleRange: "1-4"
+}),
+new Paragraph({ children: [new PageBreak()] })
+```
+
+**Note**: TOC headings must use `HeadingLevel` constants only. Do NOT combine `heading:` with `style:` on the same paragraph.
+
+## Main Content (Section 3)
+
+### Section Headings
+
+Map `## SectionName` headings to Heading 1:
+
+```javascript
+// ## Stakeholders, ## Glossary, ## Requirements, etc.
+new Paragraph({
+  heading: HeadingLevel.HEADING_1,
+  spacing: { before: 360, after: 240 },
+  children: [new TextRun(sectionTitle)]
+})
+```
+
+### Requirements
+
+```javascript
+// ### REQ-001: Title → Heading 2
+new Paragraph({
+  heading: HeadingLevel.HEADING_2,
+  spacing: { before: 300, after: 180 },
+  children: [new TextRun(`REQ-001: ${title}`)]
+})
+```
+
+### Sub-Requirements
+
+```javascript
+// #### REQ-001-1: Title → Heading 3
+new Paragraph({
+  heading: HeadingLevel.HEADING_3,
+  spacing: { before: 240, after: 120 },
+  children: [new TextRun(`REQ-001-1: ${title}`)]
+})
+```
+
+### Specifications
+
+```javascript
+// #### SPEC-001 or ##### SPEC-001 → Heading 3 or Heading 4
+new Paragraph({
+  heading: specLevel, // HeadingLevel.HEADING_3 or HEADING_4 based on nesting
+  spacing: { before: 200, after: 100 },
+  children: [new TextRun(`SPEC-001: ${title}`)]
+})
+```
+
+### Reason / Description Fields
+
+```javascript
+// **Reason**: The business justification...
+new Paragraph({
+  spacing: { before: 60, after: 60 },
+  indent: { left: 360 },
+  children: [
+    new TextRun({ text: "Reason: ", bold: true, size: 22 }),
+    new TextRun({ text: reasonText, size: 22 })
+  ]
+})
+
+// **Description**: The contextual information...
+new Paragraph({
+  spacing: { before: 60, after: 120 },
+  indent: { left: 360 },
+  children: [
+    new TextRun({ text: "Description: ", bold: true, size: 22 }),
+    new TextRun({ text: descriptionText, size: 22 })
+  ]
+})
+```
+
+### EARS Keywords in Specification Text
+
+Split specification text at keyword boundaries and apply bold formatting.
+
+```javascript
+function formatEarsText(text) {
+  const keywords = /\b(WHEN|WHILE|IF|THEN|WHERE|shall|may)\b/g;
+  const runs = [];
+  let lastIndex = 0;
+  let match;
+
+  while ((match = keywords.exec(text)) !== null) {
+    // Text before keyword
+    if (match.index > lastIndex) {
+      runs.push(new TextRun({ text: text.slice(lastIndex, match.index), size: 22 }));
+    }
+    // Keyword in bold
+    runs.push(new TextRun({ text: match[0], bold: true, size: 22 }));
+    lastIndex = match.index + match[0].length;
+  }
+
+  // Remaining text after last keyword
+  if (lastIndex < text.length) {
+    runs.push(new TextRun({ text: text.slice(lastIndex), size: 22 }));
+  }
+
+  return runs;
+}
+
+// Usage in specification paragraph
+new Paragraph({
+  spacing: { before: 60, after: 120 },
+  indent: { left: 720 },
+  children: formatEarsText(specificationText)
+})
+```
+
+### Horizontal Rule (---) Separators
+
+USDM documents use `---` between requirement groups. Render as spacing:
+
+```javascript
+// --- between requirement groups
+new Paragraph({ spacing: { before: 240, after: 240 } })
+```
+
+## Tables
+
+### Common Table Patterns
+
+All tables use the same border and header styling:
+
+```javascript
+const tableBorder = { style: BorderStyle.SINGLE, size: 1, color: "CCCCCC" };
+const cellBorders = { top: tableBorder, bottom: tableBorder, left: tableBorder, right: tableBorder };
+const headerShading = { fill: "D5E8F0", type: ShadingType.CLEAR };
+```
+
+### Header Row Pattern
+
+```javascript
+function createHeaderRow(headers, columnWidths) {
+  return new TableRow({
+    tableHeader: true,
+    children: headers.map((header, i) =>
+      new TableCell({
+        borders: cellBorders,
+        width: { size: columnWidths[i], type: WidthType.DXA },
+        shading: headerShading,
+        verticalAlign: VerticalAlign.CENTER,
+        children: [new Paragraph({
+          children: [new TextRun({ text: header, bold: true, size: 22 })]
+        })]
+      })
+    )
+  });
+}
+```
+
+### Data Row Pattern
+
+```javascript
+function createDataRow(cells, columnWidths, options = {}) {
+  return new TableRow({
+    children: cells.map((cellText, i) =>
+      new TableCell({
+        borders: cellBorders,
+        width: { size: columnWidths[i], type: WidthType.DXA },
+        children: [new Paragraph({
+          children: options.boldColumns?.includes(i)
+            ? [new TextRun({ text: cellText, bold: true, size: 22 })]
+            : [new TextRun({ text: cellText, size: 22 })]
+        })]
+      })
+    )
+  });
+}
+```
+
+### Table Column Widths (Letter size, 9360 DXA usable)
+
+| Table | Column Widths (DXA) |
+|-------|-------------------|
+| Metadata (cover) | `[3000, 5000]` |
+| Ticket References | `[2000, 2000, 5360]` |
+| Stakeholders | `[2000, 3000, 4360]` |
+| Glossary | `[2500, 6860]` |
+| Traceability Matrix | `[2340, 1800, 2880, 2340]` |
+| Open Questions | `[600, 4360, 2200, 2200]` |
+| Change History | `[1200, 1800, 2000, 4360]` |
+
+## Headers and Footers
+
+Applied to the main content section (Section 3):
+
+```javascript
+headers: {
+  default: new Header({
+    children: [new Paragraph({
+      tabStops: [
+        { type: TabStopType.RIGHT, position: TabStopPosition.MAX }
+      ],
+      children: [
+        new TextRun({ text: metadata.documentId, size: 18, color: "666666" }),
+        new TextRun({ text: "\t" }),
+        new TextRun({ text: documentTitle, size: 18, color: "666666" })
+      ]
+    })]
+  })
+},
+footers: {
+  default: new Footer({
+    children: [new Paragraph({
+      alignment: AlignmentType.CENTER,
+      children: [
+        new TextRun({ text: "Page ", size: 18, color: "666666" }),
+        new TextRun({ children: [PageNumber.CURRENT], size: 18, color: "666666" }),
+        new TextRun({ text: " of ", size: 18, color: "666666" }),
+        new TextRun({ children: [PageNumber.TOTAL_PAGES], size: 18, color: "666666" })
+      ]
+    })]
+  })
+}
+```

--- a/skills/requirements-docx/references/docx-style-definitions.md
+++ b/skills/requirements-docx/references/docx-style-definitions.md
@@ -1,0 +1,207 @@
+# docx-js Style Definitions for Requirements Documents
+
+Reusable style definitions for generating professionally formatted Word documents from USDM/EARS requirements.
+
+## Document Styles Object
+
+```javascript
+const styles = {
+  default: {
+    document: {
+      run: {
+        font: "Arial",
+        size: 22 // 11pt
+      }
+    }
+  },
+  paragraphStyles: [
+    {
+      id: "Title",
+      name: "Title",
+      basedOn: "Normal",
+      run: {
+        size: 56, // 28pt
+        bold: true,
+        color: "000000",
+        font: { ascii: "Arial", eastAsia: "Yu Gothic", hAnsi: "Arial" }
+      },
+      paragraph: {
+        spacing: { before: 240, after: 120 },
+        alignment: AlignmentType.CENTER
+      }
+    },
+    {
+      id: "Heading1",
+      name: "Heading 1",
+      basedOn: "Normal",
+      next: "Normal",
+      quickFormat: true,
+      run: {
+        size: 32, // 16pt
+        bold: true,
+        color: "1F3864",
+        font: { ascii: "Arial", eastAsia: "Yu Gothic", hAnsi: "Arial" }
+      },
+      paragraph: {
+        spacing: { before: 360, after: 240 },
+        outlineLevel: 0
+      }
+    },
+    {
+      id: "Heading2",
+      name: "Heading 2",
+      basedOn: "Normal",
+      next: "Normal",
+      quickFormat: true,
+      run: {
+        size: 28, // 14pt
+        bold: true,
+        color: "1F3864",
+        font: { ascii: "Arial", eastAsia: "Yu Gothic", hAnsi: "Arial" }
+      },
+      paragraph: {
+        spacing: { before: 300, after: 180 },
+        outlineLevel: 1
+      }
+    },
+    {
+      id: "Heading3",
+      name: "Heading 3",
+      basedOn: "Normal",
+      next: "Normal",
+      quickFormat: true,
+      run: {
+        size: 24, // 12pt
+        bold: true,
+        color: "404040",
+        font: { ascii: "Arial", eastAsia: "Yu Gothic", hAnsi: "Arial" }
+      },
+      paragraph: {
+        spacing: { before: 240, after: 120 },
+        outlineLevel: 2
+      }
+    },
+    {
+      id: "Heading4",
+      name: "Heading 4",
+      basedOn: "Normal",
+      next: "Normal",
+      quickFormat: true,
+      run: {
+        size: 22, // 11pt
+        bold: true,
+        color: "404040",
+        font: { ascii: "Arial", eastAsia: "Yu Gothic", hAnsi: "Arial" }
+      },
+      paragraph: {
+        spacing: { before: 200, after: 100 },
+        outlineLevel: 3
+      }
+    }
+  ]
+};
+```
+
+## Color Palette
+
+| Purpose | Color Code | Preview |
+|---------|-----------|---------|
+| Heading 1, 2 | `1F3864` | Dark blue |
+| Heading 3, 4 | `404040` | Dark gray |
+| Body text | `000000` | Black |
+| Table header background | `D5E8F0` | Light blue |
+| Table borders | `CCCCCC` | Light gray |
+| Header/footer text | `666666` | Medium gray |
+| Confidentiality notice | `666666` | Medium gray |
+| Logo placeholder text | `999999` | Light gray |
+
+## Table Styling Constants
+
+```javascript
+const tableBorder = {
+  style: BorderStyle.SINGLE,
+  size: 1,
+  color: "CCCCCC"
+};
+
+const cellBorders = {
+  top: tableBorder,
+  bottom: tableBorder,
+  left: tableBorder,
+  right: tableBorder
+};
+
+const headerShading = {
+  fill: "D5E8F0",
+  type: ShadingType.CLEAR  // CRITICAL: Always use CLEAR, never SOLID
+};
+
+const tableMargins = {
+  top: 80,
+  bottom: 80,
+  left: 120,
+  right: 120
+};
+```
+
+## Page Layout
+
+```javascript
+const pageProperties = {
+  page: {
+    margin: {
+      top: 1440,    // 1 inch
+      right: 1440,
+      bottom: 1440,
+      left: 1440
+    },
+    pageNumbers: {
+      start: 1,
+      formatType: "decimal"
+    }
+  }
+};
+```
+
+## Font Configuration
+
+The font configuration supports both English and Japanese text:
+
+```javascript
+// Default font for body text
+const bodyFont = { ascii: "Arial", eastAsia: "Yu Gothic", hAnsi: "Arial" };
+
+// Apply to individual TextRuns when needed
+new TextRun({
+  text: content,
+  font: bodyFont,
+  size: 22
+})
+```
+
+**Note**: The default document font (`styles.default.document.run.font`) only accepts a string value (`"Arial"`). Use the font object with `ascii`/`eastAsia`/`hAnsi` properties on individual TextRun or paragraph style definitions for full bilingual support.
+
+## Numbering Configuration
+
+For bullet lists and numbered lists within the document:
+
+```javascript
+const numbering = {
+  config: [
+    {
+      reference: "bullet-list",
+      levels: [{
+        level: 0,
+        format: LevelFormat.BULLET,
+        text: "\u2022",
+        alignment: AlignmentType.LEFT,
+        style: {
+          paragraph: {
+            indent: { left: 720, hanging: 360 }
+          }
+        }
+      }]
+    }
+  ]
+};
+```


### PR DESCRIPTION
## Summary

- USDM/EARS要件定義書（Markdown）をクライアント提出用Word (.docx) に変換する `requirements-docx` スキルを追加
- 表紙・目次・ヘッダーフッター・EARSキーワード太字表示・全メタデータテーブルを含むビジネス文書レベルの出力に対応
- 要件定義書 `REQ-DOC-20260221-001-requirements-docx.md` を同梱（SPEC 26件）

## Changes

- `skills/requirements-docx/SKILL.md` — コアスキル定義（5ステップワークフロー）
- `skills/requirements-docx/references/document-structure-mapping.md` — Markdown→Word マッピングとdocx-jsコードパターン
- `skills/requirements-docx/references/docx-style-definitions.md` — スタイルオブジェクト定義
- `skills/requirements-docx/examples/conversion-example.md` — 変換前後の具体例
- `skills/requirements-docx/.claude-plugin/plugin.json` — スキルマニフェスト
- `.claude-plugin/marketplace.json`, `.claude-plugin/plugin.json` — スキル登録・version 0.1.4

## Test plan

- [ ] `requirements-docx` スキルをインストールし、トリガーワード（"要件書をWord出力" 等）で正しく呼び出されることを確認
- [ ] `REQ-DOC-20260221-001-requirements-docx.md` を入力としてWord変換を実行し、.docxファイルが生成されることを確認
- [ ] 生成文書の体裁を確認（表紙、目次、見出し階層、EARSキーワード太字、テーブル書式、ヘッダーフッター）

Closes #3