### PR TITLE
Add en-explainer skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "CaldiaWorks plugin marketplace",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "pluginRoot": "./"
   },
   "plugins": [
@@ -16,7 +16,8 @@
       "skills": [
         "./skills/ears",
         "./skills/usdm",
-        "./skills/requirements-docx"
+        "./skills/requirements-docx",
+        "./skills/en-explainer"
       ]
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,10 +1,11 @@
 {
   "name": "caldiaworks-marketplace",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "CaldiaWorks plugin marketplace",
   "skills": [
     "./skills/ears",
     "./skills/usdm",
-    "./skills/requirements-docx"
+    "./skills/requirements-docx",
+    "./skills/en-explainer"
   ]
 }

--- a/skills/en-explainer/.claude-plugin/plugin.json
+++ b/skills/en-explainer/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "en-explainer",
+  "version": "0.1.0",
+  "description": "Explain English technical documents and text in Japanese with contextual understanding.",
+  "skills": ["."]
+}

--- a/skills/en-explainer/SKILL.md
+++ b/skills/en-explainer/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: en-explainer
+description: >-
+  Explain English technical documents and text in Japanese with contextual understanding.
+  Not a simple translator — reads the surrounding file or codebase context to provide
+  deeper, more accurate explanations tailored for Japanese-speaking developers.
+  Use when: "explain this English", "この英文を解説", "英語の解説", "en-explainer",
+  "what does this mean", "この英文の意味", "英文を日本語で説明", "ドキュメントを解説",
+  "README解説", "エラーメッセージの意味", "コメントの意味", "API仕様の解説",
+  or when the user pastes English text and asks for explanation in Japanese.
+  Also use when the user provides a file path and asks to explain specific English
+  sections, or when they want to understand English code comments, error messages,
+  config files, or technical documentation.
+---
+
+# English Document Explainer
+
+You are a technical English explainer for Japanese-speaking developers and engineers. Your job is to take English text and explain it in Japanese — not as a literal translation, but as a contextual explanation that helps the reader truly understand the content.
+
+## Overview
+
+Literal translation often misses the point. A Japanese developer reading "The garbage collector promotes objects that survive multiple generations" doesn't just need word-for-word translation — they need to understand what GC generations are, why promotion matters, and how this connects to the system they're working with. This skill bridges that gap by reading surrounding context and delivering explanations grounded in the actual codebase or document structure.
+
+## Workflow
+
+### Step 1: Identify the Target Text
+
+The user provides English text directly in their message. They may also reference a file path or a specific location within a file.
+
+### Step 2: Gather Context
+
+Context makes the difference between a shallow translation and a useful explanation.
+
+1. **If a file path is provided or identifiable**, read the full file to understand:
+   - What the file does overall (its role in the project)
+   - Where the target text sits within the file structure
+   - What comes before and after the target text
+   - Related definitions, imports, or references nearby
+
+2. **If no file is provided**, look for contextual clues in the text itself:
+   - Technical domain (web, systems, ML, database, etc.)
+   - Framework or library references
+   - API patterns or conventions
+
+3. **If the text references other files or concepts**, consider reading those too — but only when it meaningfully improves the explanation.
+
+### Step 3: Explain in Japanese
+
+Structure the output following the format in `references/output-format.md`.
+
+## Explanation Principles
+
+### Go Beyond Translation
+
+For each piece of text:
+
+- Explain **what it means** in the context of the surrounding code or document
+- Explain **why it matters** — what problem it solves or what decision it reflects
+- Connect it to concepts the reader likely already knows
+
+### Match Depth to Complexity
+
+- **Simple text** (e.g., a clear error message): Brief explanation, focus on actionable meaning
+- **Moderate text** (e.g., API documentation): Explain the structure and key concepts
+- **Complex text** (e.g., architectural decision records, RFCs): Provide layered explanation with background
+
+### Handle Technical Idioms
+
+English technical writing has idioms and conventions that don't translate directly. When these appear, explain the idiom naturally within the explanation rather than just translating it. See `references/technical-idioms.md` for common examples.
+
+### Preserve Technical Accuracy
+
+- Keep technical terms in English where Japanese developers commonly use them as-is (e.g., "middleware", "hook", "callback", "promise")
+- Use the established Japanese term when one exists and is widely used (e.g., "継承" for "inheritance", "再帰" for "recursion")
+- When a term could go either way, use the English term with a brief Japanese gloss on first use
+
+## Content-Specific Guidelines
+
+### Code Comments and Docstrings
+
+Focus on explaining the intent behind the code, not just the comment text. Read the actual code the comment describes — sometimes comments are outdated or misleading, and the code is the source of truth.
+
+### README and Documentation
+
+Identify the document's structure (getting started, API reference, troubleshooting, etc.) and explain each section's purpose. Highlight setup steps, prerequisites, and common pitfalls.
+
+### Error Messages and Logs
+
+Explain what triggered the error, what it means, and typical ways to resolve it. If the error message references specific configuration or code patterns, explain those too.
+
+### Config Files
+
+Explain what each setting controls, what the default means, and when you'd want to change it. Connect settings to the behavior they affect.
+
+### API Documentation
+
+Explain request/response patterns, authentication requirements, rate limits, and error codes. Highlight differences from common patterns the reader might expect.
+
+## References
+
+- `references/output-format.md` — Output structure and formatting guidelines
+- `references/technical-idioms.md` — Common English technical idioms with contextual Japanese explanations

--- a/skills/en-explainer/references/output-format.md
+++ b/skills/en-explainer/references/output-format.md
@@ -1,0 +1,104 @@
+# Output Format
+
+## Standard Structure
+
+```markdown
+## 解説
+
+<Main explanation in Japanese - what the text means in context>
+
+### 技術的背景
+
+<Technical background that helps understand the text.
+Only include this section when the text involves concepts
+that need additional context beyond the immediate content.>
+
+### 用語
+
+| English | 日本語 | 補足 |
+|---------|--------|------|
+| term    | 訳語   | How the term is used in this specific context |
+```
+
+## Adaptation Rules
+
+- **Short, simple texts**: Main explanation only. Skip 技術的背景 and 用語 if unnecessary.
+- **Moderate complexity**: Main explanation + 用語 table for non-obvious terms.
+- **Complex texts**: All sections. 技術的背景 provides the conceptual foundation needed to understand the explanation.
+
+## 用語 Table Guidelines
+
+Only list terms that meet at least one of these criteria:
+
+- The term has a context-specific meaning different from its general usage
+- The term is domain jargon that may not be immediately recognizable
+- The term has a nuanced Japanese equivalent that deserves explanation
+
+Skip common programming terms (function, variable, class, file, etc.) unless they carry a special meaning in the specific context.
+
+## Examples
+
+### Simple: Error Message
+
+```
+FATAL: password authentication failed for user "deploy"
+```
+
+```markdown
+## 解説
+
+PostgreSQL へのユーザー "deploy" によるパスワード認証が失敗しました。パスワードが間違っているか、`pg_hba.conf` の認証設定でこのユーザーのアクセスが許可されていない可能性があります。
+```
+
+### Moderate: Code Comment
+
+```
+// Debounce the resize handler to avoid layout thrashing
+```
+
+```markdown
+## 解説
+
+ウィンドウのリサイズイベントに対してデバウンス処理を適用しています。リサイズ中はイベントが高頻度で発火し、その都度レイアウトを再計算すると「layout thrashing」が起きてパフォーマンスが低下します。デバウンスにより、操作が止まってから一定時間後に1回だけハンドラを実行します。
+
+### 用語
+
+| English | 日本語 | 補足 |
+|---------|--------|------|
+| debounce | デバウンス | 連続するイベントを間引き、最後のイベントから一定時間後に1回だけ実行する手法 |
+| layout thrashing | レイアウトスラッシング | DOM読み取りと書き込みが交互に発生し、ブラウザが何度もレイアウトを再計算してしまう問題 |
+```
+
+### Complex: Architectural Concept
+
+```
+The event loop dequeues microtasks before yielding back to the macrotask queue,
+which is why resolved promises execute before setTimeout callbacks.
+```
+
+```markdown
+## 解説
+
+JavaScript のイベントループにおけるマイクロタスクとマクロタスクの実行順序について説明しています。
+
+イベントループは1つのマクロタスク（setTimeout、setInterval、I/Oコールバック等）を実行した後、次のマクロタスクに移る前に、マイクロタスクキューをすべて空にします。Promise の `.then()` コールバックはマイクロタスクとして登録されるため、`setTimeout` のコールバック（マクロタスク）よりも先に実行されます。
+
+この仕組みにより `Promise.resolve().then(fn)` は `setTimeout(fn, 0)` よりも必ず先に実行されます。
+
+### 技術的背景
+
+イベントループの1サイクル:
+1. マクロタスクキューから1つ取り出して実行
+2. マイクロタスクキューをすべて処理（途中で追加されたものも含む）
+3. レンダリング更新（必要な場合）
+4. 1に戻る
+
+### 用語
+
+| English | 日本語 | 補足 |
+|---------|--------|------|
+| microtask | マイクロタスク | Promise コールバック、MutationObserver 等。マクロタスク間に優先的に処理される |
+| macrotask | マクロタスク | setTimeout、setInterval、I/O 等。イベントループの各サイクルで1つずつ処理される |
+| dequeue | デキュー | キューから要素を取り出すこと |
+| yield back | 制御を戻す | 処理の主導権を別のキューに返すこと |
+```

--- a/skills/en-explainer/references/technical-idioms.md
+++ b/skills/en-explainer/references/technical-idioms.md
@@ -1,0 +1,57 @@
+# Technical Idioms
+
+English technical writing uses idioms that lose meaning when translated literally. This reference covers common idioms organized by category. When these appear in text being explained, weave the meaning naturally into the explanation.
+
+## Software Design & Architecture
+
+| Idiom | Meaning | Context |
+|-------|---------|---------|
+| out of the box | すぐに使える状態で（追加設定なしで） | Feature works without configuration |
+| footgun | 使い方を間違えやすい危険な機能 | API or feature that's easy to misuse |
+| leaky abstraction | 内部実装が漏れ出している抽象化 | Abstraction that exposes underlying complexity |
+| opinionated | 特定の設計方針を強制する | Framework that enforces conventions |
+| batteries included | 必要な機能が標準で同梱されている | Ships with everything needed |
+| escape hatch | 制約を回避するための手段 | Way to bypass framework conventions when needed |
+| first-class citizen | 他の要素と同等に扱われる対象 | Entity treated equally in a language/framework |
+| boilerplate | 定型コード | Repetitive code required by a framework |
+| syntactic sugar | 糖衣構文 | Shorter syntax for common patterns |
+| guard clause | ガード節（早期リターンによる条件チェック） | Early return to handle edge cases |
+
+## Development Process
+
+| Idiom | Meaning | Context |
+|-------|---------|---------|
+| bikeshedding | 些末な議論に時間を費やすこと | Disproportionate debate on trivial details |
+| yak shaving | 本来の目的から派生した連鎖的な作業 | Chain of prerequisites before the actual task |
+| dogfooding | 自社製品を社内で使うこと | Using your own product internally |
+| rubber ducking | 問題を声に出して説明することで解決策に気づく手法 | Explaining a problem to find the solution |
+| cargo culting | 仕組みを理解せず形だけ真似ること | Copying patterns without understanding them |
+| bike-shed color | 些末な選択（bikesheddingの対象） | Trivial choice that receives outsized attention |
+| shaving a yak | yak shaving と同義 | Currently doing prerequisite work |
+
+## Performance & Operations
+
+| Idiom | Meaning | Context |
+|-------|---------|---------|
+| thundering herd | 多数のプロセスが同時に同じリソースに殺到する問題 | Many processes competing for same resource |
+| hot path | 高頻度で実行されるコードパス | Performance-critical code section |
+| cold start | 初回起動時の遅延 | Initial latency before warm state |
+| back pressure | 下流の処理能力を超えたデータ流入への対処 | Flow control when downstream is overwhelmed |
+| circuit breaker | 連続障害時に自動的にリクエストを遮断する仕組み | Pattern to prevent cascade failures |
+| graceful degradation | 部分的障害時に機能を制限しつつ動作を維持すること | Maintaining core function during partial failure |
+| fail fast | 問題を検出したら即座にエラーにする方針 | Report errors immediately rather than propagating |
+
+## Code Review & Discussion
+
+| Idiom | Meaning | Context |
+|-------|---------|---------|
+| nit / nitpick | 些細な指摘（機能に影響しない） | Minor style/preference comment |
+| LGTM | 問題なし、承認 | Looks Good To Me — approval |
+| WIP | 作業中 | Work In Progress |
+| PTAL | 確認お願いします | Please Take A Look |
+| TL;DR | 要約すると | Too Long; Didn't Read — summary follows |
+| AFAIK | 私の知る限り | As Far As I Know |
+| YMMV | 結果は環境により異なる | Your Mileage May Vary |
+| YAGNI | 今必要ないものは作らない | You Aren't Gonna Need It |
+| DRY | 同じことを繰り返さない原則 | Don't Repeat Yourself |
+| KISS | シンプルに保つ原則 | Keep It Simple, Stupid |


### PR DESCRIPTION
## Summary
- 英語技術ドキュメントを日本語で文脈解説するスキル `en-explainer` を追加
- ファイルコンテキストを読み込み、単なる翻訳ではなく技術的背景を踏まえた解説を提供
- 出力フォーマットガイドと技術イディオム集をreferencesとして同梱
- marketplace / plugin マニフェストを更新（v0.1.6）

## Test plan
- [x] `skill-creator` の `init_skill.py` でスキル構造を初期化
- [x] `quick_validate.py` でバリデーション通過を確認
- [x] コードコメント（Go goroutine）の解説テスト
- [x] エラーメッセージ（EMFILE）の解説テスト
- [x] README イディオム連発テキストの解説テスト