### PR TITLE
Bump marketplace version to 0.1.9

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "CaldiaWorks plugin marketplace",
-    "version": "0.1.8",
+    "version": "0.1.9",
     "pluginRoot": "./"
   },
   "plugins": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "caldiaworks-marketplace",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "CaldiaWorks plugin marketplace",
   "skills": [
     "./skills/ears",


### PR DESCRIPTION
## Summary
- Bump marketplace version to 0.1.9 in both `plugin.json` and `marketplace.json`
- Required for `npx skills update` to detect skill-create-workflow changes