### PR TITLE
Bump marketplace version to 0.1.11

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "CaldiaWorks plugin marketplace",
-    "version": "0.1.10",
+    "version": "0.1.11",
     "pluginRoot": "./"
   },
   "plugins": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "caldiaworks-marketplace",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "CaldiaWorks plugin marketplace",
   "skills": [
     "./skills/ears",


### PR DESCRIPTION
## Summary
- Bump marketplace manifests to 0.1.11 to reflect usdm skill v0.2.2 changes (W011 mitigation from #14)

## Changes
- **`.claude-plugin/plugin.json`**: version 0.1.10 → 0.1.11
- **`.claude-plugin/marketplace.json`**: version 0.1.10 → 0.1.11

## Test plan
- [ ] Verify marketplace correctly picks up updated usdm skill