### PR TITLE
Release: add issue closing keyword rule to git-workflow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "CaldiaWorks plugin marketplace",
-    "version": "0.1.12",
+    "version": "0.1.13",
     "pluginRoot": "./"
   },
   "plugins": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "caldiaworks-marketplace",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "CaldiaWorks plugin marketplace",
   "skills": [
     "./skills/ears",

--- a/skills/git-workflow/.claude-plugin/plugin.json
+++ b/skills/git-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-workflow",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Automate Git workflows driven by project-specific config.",
   "skills": ["."]
 }

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -103,6 +103,7 @@ Execute in this order:
 
 - Read the 5 most recent commit messages to match the repository's existing style.
 - Generate a commit message draft based on the diff content and the commit convention in the config.
+- IF the current branch name matches `feature/<number>-*` or `fix/<number>-*`, THEN include `Closes #<number>` in the commit message body so that the related issue is automatically closed when merged to the default branch.
 - Present the message to the user and wait for approval or modification.
 
 **5. Commit execution**


### PR DESCRIPTION
## Summary
- Add rule to git-workflow commit workflow: include `Closes #N` in commit messages when branch name contains an issue number
- Bump marketplace version to 0.1.13, git-workflow to 0.1.1

## Included PRs
- #21 (feature/20-commit-closes-keyword → develop)