### PR TITLE
Release: add branch cleanup step to skill-create-workflow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "CaldiaWorks plugin marketplace",
-    "version": "0.1.13",
+    "version": "0.1.14",
     "pluginRoot": "./"
   },
   "plugins": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "caldiaworks-marketplace",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "CaldiaWorks plugin marketplace",
   "skills": [
     "./skills/ears",

--- a/skills/skill-create-workflow/.claude-plugin/plugin.json
+++ b/skills/skill-create-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-create-workflow",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Orchestrate the full skill development lifecycle from idea to publication",
   "skills": ["."]
 }

--- a/skills/skill-create-workflow/SKILL.md
+++ b/skills/skill-create-workflow/SKILL.md
@@ -113,3 +113,12 @@ Before reporting completion, verify all artifacts are consistent.
 3. Every skill listed in the manifests exists under `skills/<name>/` with a `SKILL.md` and `.claude-plugin/plugin.json`.
 4. Every skill listed in the manifests has an entry in `README.md` (install command + table row).
 5. No unintended files were added to `.gitignore` — check that existing patterns are not duplicated.
+
+### Step 7: Branch Cleanup
+
+After all PRs are merged and the workflow is complete, clean up the working environment.
+
+1. Switch back to the `develop` branch and pull the latest changes.
+2. Run `git fetch --prune` to update remote tracking state.
+3. Delete local feature branches created during this workflow whose upstream is gone.
+4. Verify the working tree is clean with `git status`.


### PR DESCRIPTION
## Summary
- Add Step 7 (Branch Cleanup) to skill-create-workflow
- Bump skill-create-workflow to 0.1.3, marketplace to 0.1.14

## Included PRs
- #24 (feature/23-workflow-branch-cleanup → develop)