### PR TITLE
Release 0.1.15: Complete workflow cleanup steps

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "CaldiaWorks plugin marketplace",
-    "version": "0.1.14",
+    "version": "0.1.15",
     "pluginRoot": "./"
   },
   "plugins": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "caldiaworks-marketplace",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "CaldiaWorks plugin marketplace",
   "skills": [
     "./skills/ears",

--- a/skills/skill-create-workflow/.claude-plugin/plugin.json
+++ b/skills/skill-create-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-create-workflow",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Orchestrate the full skill development lifecycle from idea to publication",
   "skills": ["."]
 }

--- a/skills/skill-create-workflow/SKILL.md
+++ b/skills/skill-create-workflow/SKILL.md
@@ -119,6 +119,8 @@ Before reporting completion, verify all artifacts are consistent.
 After all PRs are merged and the workflow is complete, clean up the working environment.
 
 1. Switch back to the `develop` branch and pull the latest changes.
-2. Run `git fetch --prune` to update remote tracking state.
-3. Delete local feature branches created during this workflow whose upstream is gone.
-4. Verify the working tree is clean with `git status`.
+2. Delete remote feature branches created during this workflow using `git push origin --delete <branch>`.
+3. Run `git fetch --prune` to update remote tracking state.
+4. Delete local feature branches created during this workflow whose upstream is gone.
+5. Delete the eval workspace directory if it exists (`skills/<skill-name>-workspace/`).
+6. Verify the working tree is clean with `git status` and `git branch -a`.


### PR DESCRIPTION
## Summary

- Complete Step 7 (Branch Cleanup) in skill-create-workflow with missing actions: remote branch deletion, eval workspace removal, `git branch -a` verification
- Bump skill-create-workflow to 0.1.4, marketplace to 0.1.15

## PRs included

- #27 Complete branch cleanup steps in skill-create-workflow Step 7 (Closes #26)