### PR TITLE
Refactor deep-research skill with orchestrator-worker model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 **.local.**
 
 CLAUDE.md
+GEMINI.md
 tmp**
 
 .agent/
@@ -9,3 +10,4 @@ tmp**
 skills-lock.json
 .docs/
 *-workspace/
+**/evals/

--- a/skills/deep-research/.claude-plugin/plugin.json
+++ b/skills/deep-research/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deep-research",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Conduct deep research through structured investigation design: question decomposition, plan approval, iterative exploration, and synthesis.",
   "skills": ["."]
 }


### PR DESCRIPTION
## Summary
- Rewrite SKILL.md to implement LeadResearcher (orchestrator) + Subagent (worker) delegation model
- Add per-question investigation angle formatting, inline single-source claim flagging, stricter citation requirements, and Task tool fallback
- Bump skill version to 0.2.0

## Test plan
- [ ] Verify SKILL.md triggers correctly on "deep research" and related phrases
- [ ] Verify Phase 2 lists investigation angles per question (not by wave)
- [ ] Verify Phase 4 flags single-sourced claims inline in report text
- [ ] Verify all factual claims in generated reports carry citations

Closes #33