### PR TITLE
Fix skill descriptions not rendering on skills.sh

### DIFF
--- a/skills/deep-research/SKILL.md
+++ b/skills/deep-research/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: deep-research
-description: >
-  Conduct deep research on any topic through structured investigation design.
-  Use when the user needs comprehensive, multi-source analysis — not a quick
-  lookup. Triggers: "deep research", "comprehensive analysis", "research report",
-  "compare X vs Y", "analyze trends", "investigate", or any request requiring
-  synthesis across multiple perspectives. Do NOT use for simple questions
-  answerable with 1-2 searches or for debugging.
+description: "Conduct deep research on any topic through structured investigation design. Use when the user needs comprehensive, multi-source analysis -- not a quick lookup. Triggers: deep research, comprehensive analysis, research report, compare X vs Y, analyze trends, investigate, or any request requiring synthesis across multiple perspectives. Do NOT use for simple questions answerable with 1-2 searches or for debugging."
 ---
 
 # Deep Research

--- a/skills/ears/SKILL.md
+++ b/skills/ears/SKILL.md
@@ -1,12 +1,7 @@
 ---
 name: ears
 version: 0.1.0
-description: >-
-  Write unambiguous specifications using EARS (Easy Approach to Requirements Syntax) patterns.
-  Provides 6 sentence templates that eliminate ambiguity: Ubiquitous, Event-driven, State-driven,
-  Unwanted behavior, Optional feature, and Complex.
-  Use when: "EARS", "specification writing", "write specs", "仕様を書く", "EARS記法",
-  "仕様を明確化", "requirements specification", "unambiguous specification".
+description: "Write unambiguous specifications using EARS (Easy Approach to Requirements Syntax) patterns. Provides 6 sentence templates that eliminate ambiguity: Ubiquitous, Event-driven, State-driven, Unwanted behavior, Optional feature, and Complex. Use when: EARS, specification writing, write specs, 仕様を書く, EARS記法, 仕様を明確化, requirements specification, unambiguous specification."
 ---
 
 # EARS Specification Writing

--- a/skills/en-explainer/SKILL.md
+++ b/skills/en-explainer/SKILL.md
@@ -1,16 +1,6 @@
 ---
 name: en-explainer
-description: >-
-  Explain English technical documents and text in Japanese with contextual understanding.
-  Not a simple translator — reads the surrounding file or codebase context to provide
-  deeper, more accurate explanations tailored for Japanese-speaking developers.
-  Use when: "explain this English", "この英文を解説", "英語の解説", "en-explainer",
-  "what does this mean", "この英文の意味", "英文を日本語で説明", "ドキュメントを解説",
-  "README解説", "エラーメッセージの意味", "コメントの意味", "API仕様の解説",
-  or when the user pastes English text and asks for explanation in Japanese.
-  Also use when the user provides a file path and asks to explain specific English
-  sections, or when they want to understand English code comments, error messages,
-  config files, or technical documentation.
+description: "Explain English technical documents and text in Japanese with contextual understanding. Not a simple translator -- reads the surrounding file or codebase context to provide deeper, more accurate explanations tailored for Japanese-speaking developers. Use when: explain this English, この英文を解説, 英語の解説, en-explainer, what does this mean, この英文の意味, 英文を日本語で説明, ドキュメントを解説, README解説, エラーメッセージの意味, コメントの意味, API仕様の解説, or when the user pastes English text and asks for explanation in Japanese. Also use when the user provides a file path and asks to explain specific English sections, or when they want to understand English code comments, error messages, config files, or technical documentation."
 ---
 
 # English Document Explainer

--- a/skills/ideation/SKILL.md
+++ b/skills/ideation/SKILL.md
@@ -1,13 +1,7 @@
 ---
 name: ideation
 version: 0.1.0
-description: >-
-  Turn rough ideas into structured, validated idea documents through collaborative dialogue.
-  Explores context, asks clarifying questions one at a time, proposes alternative approaches
-  with feasibility evaluation, and produces documents ready for requirements definition.
-  Use when: "ideation", "brainstorm", "new idea", "explore an idea", "I want to build",
-  "what if we", "let's think about", "propose approaches", "evaluate this idea",
-  "idea document", "アイデア出し", "案出し", "ブレスト", "アイデアを整理", "検討したい".
+description: "Turn rough ideas into structured, validated idea documents through collaborative dialogue. Explores context, asks clarifying questions one at a time, proposes alternative approaches with feasibility evaluation, and produces documents ready for requirements definition. Use when: ideation, brainstorm, new idea, explore an idea, I want to build, what if we, let's think about, propose approaches, evaluate this idea, idea document, アイデア出し, 案出し, ブレスト, アイデアを整理, 検討したい."
 ---
 
 # Ideation: Ideas Into Structured Documents

--- a/skills/requirements-docx/SKILL.md
+++ b/skills/requirements-docx/SKILL.md
@@ -1,14 +1,7 @@
 ---
 name: requirements-docx
 version: 0.1.0
-description: >-
-  Convert USDM/EARS requirements documents from Markdown to professionally
-  formatted Word (.docx) files for client submission. Generates cover pages,
-  table of contents, headers/footers, and styled requirement hierarchies.
-  Leverages the docx skill for Word file generation.
-  Use when: "export requirements to Word", "requirements to docx", "USDM to Word",
-  "convert requirements document", "要件書をWord出力", "要件定義書のdocx変換",
-  "Word形式で要件書を作成", "要件定義書をWordに変換".
+description: "Convert USDM/EARS requirements documents from Markdown to professionally formatted Word (.docx) files for client submission. Generates cover pages, table of contents, headers/footers, and styled requirement hierarchies. Leverages the docx skill for Word file generation. Use when: export requirements to Word, requirements to docx, USDM to Word, convert requirements document, 要件書をWord出力, 要件定義書のdocx変換, Word形式で要件書を作成, 要件定義書をWordに変換."
 ---
 
 # USDM/EARS Requirements Document — Word Export

--- a/skills/skill-create-workflow/SKILL.md
+++ b/skills/skill-create-workflow/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: skill-create-workflow
-description: >-
-  Orchestrate the full skill development lifecycle from idea to publication.
-  Guides through ideation, requirements definition, skill implementation, and marketplace registration.
-  Use when: "create a new skill end-to-end", "skill development workflow", "build and publish a skill",
-  "スキル開発ワークフロー", "スキルを作って公開", "新しいスキルを開発".
+description: "Orchestrate the full skill development lifecycle from idea to publication. Guides through ideation, requirements definition, skill implementation, and marketplace registration. Use when: create a new skill end-to-end, skill development workflow, build and publish a skill, スキル開発ワークフロー, スキルを作って公開, 新しいスキルを開発."
 ---
 
 # Skill Development Workflow

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -220,6 +220,7 @@ Based on interview, fill:
 
 - **name**: Skill identifier
 - **description**: When to trigger, what it does. This is the primary triggering mechanism - include both what the skill does AND specific contexts for when to use it. All "when to use" info goes here, not in the body. Note: currently Claude has a tendency to "undertrigger" skills -- to not use them when they'd be useful. To combat this, please make the skill descriptions a little bit "pushy". So for instance, instead of "How to build a simple fast dashboard to display internal Anthropic data.", you might write "How to build a simple fast dashboard to display internal Anthropic data. Make sure to use this skill whenever the user mentions dashboards, data visualization, internal metrics, or wants to display any kind of company data, even if they don't explicitly ask for a 'dashboard.'"
+  **Format constraint**: The description MUST be a single-line value -- either plain (`description: Some text`) or double-quoted (`description: "Some text"`). NEVER use YAML block scalar syntax (`>`, `>-`, `|`, `|-`) because many marketplace parsers do not expand them and will display the raw indicator character instead of the description text. Also avoid special Unicode characters like `→` or `—` in the description; use ASCII equivalents (`->`, `--`) instead.
 - **compatibility**: Required tools, dependencies (optional, rarely needed)
 
 ### Skill Writing Guide

--- a/skills/skill-creator/scripts/init_skill.py
+++ b/skills/skill-creator/scripts/init_skill.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 SKILL_TEMPLATE = """---
 name: {skill_name}
-description: [TODO: Complete and informative explanation of what the skill does and when to use it. Include WHEN to use this skill - specific scenarios, file types, or tasks that trigger it.]
+description: "[TODO: Single-line description of what the skill does and when to use it. MUST stay on one line -- never use YAML block scalars (>, >-, |). Avoid special Unicode characters. Include WHEN to use this skill - specific scenarios, file types, or tasks that trigger it.]"
 ---
 
 # {skill_title}

--- a/skills/usdm/SKILL.md
+++ b/skills/usdm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: usdm
 version: 0.2.2
-description: "Convert ambiguous user requests into structured USDM requirements documents. Decomposes requirements into Requirement → Reason → Description → Specification hierarchy. Integrates with GitHub Issues, Asana, and Jira tickets as input sources. Use when: create requirements, write requirements document, USDM, decompose requirements, requirements definition, 要件定義, 要件を整理, 要件分解."
+description: "Convert ambiguous user requests into structured USDM requirements documents. Decomposes requirements into Requirement -> Reason -> Description -> Specification hierarchy. Integrates with GitHub Issues, Asana, and Jira tickets as input sources. Use when: create requirements, write requirements document, USDM, decompose requirements, requirements definition, 要件定義, 要件を整理, 要件分解."
 ---
 
 # USDM Requirements Decomposition


### PR DESCRIPTION
## Summary
- Convert YAML block scalar syntax (`>-`, `>`) to single-line quoted strings in 7 SKILL.md frontmatter descriptions that were rendering as literal `>—` or `>` on skills.sh
- Replace special Unicode character `→` with `->` in usdm description
- Add format constraint guidance to skill-creator SKILL.md and init_skill.py template to prevent recurrence

## Test plan
- [ ] Verify all 9 skills display correct descriptions on skills.sh after merge to main
- [ ] Confirm skill-creator generates new skills with single-line description format

Closes #36