### PR TITLE
Add completion checklists to workflow skills

### DIFF
--- a/skills/commit/.claude-plugin/plugin.json
+++ b/skills/commit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "commit",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Create focused git commits with change review, selective staging, and auto-drafted messages.",
   "skills": ["."]
 }

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: commit
-version: 0.1.0
+version: 0.2.0
 description: "Create focused git commits with change review, selective staging, and auto-drafted messages. Use when: commit, git commit, save changes, commit my work, make a commit, stage and commit, review changes before committing. Also use when the user says /commit or asks to commit specific files."
 ---
 
@@ -53,6 +53,12 @@ EOF
 ### Error Recovery
 
 **Pre-commit hook failure**: If a pre-commit hook fails, display the hook's error output. After the user fixes the issue, create a new commit -- never use `--amend`, because the failed commit did not happen and amending would modify the previous (unrelated) commit.
+
+## Before Finishing
+
+After creating the commit, check for leftover changes:
+
+- **Remaining changes?** Run `git status` after the commit. If unstaged changes remain, inform the user -- they may be related changes that should be included, or incidental changes that need a plan for when they will be committed.
 
 ## Constraints
 

--- a/skills/issue-create/.claude-plugin/plugin.json
+++ b/skills/issue-create/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "issue-create",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Create GitHub Issues from user input or USDM requirements documents.",
   "skills": ["."]
 }

--- a/skills/issue-create/SKILL.md
+++ b/skills/issue-create/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-create
-version: 0.1.0
+version: 0.2.0
 description: "Create GitHub Issues from user input or USDM requirements documents. Standalone mode guides through title, body, and labels. USDM mode creates a hierarchy of issues from requirements with specifications in the issue body. Use when: create issue, new issue, GitHub issue, open issue, file issue, create issues from requirements, USDM to issues, issue-create, /issue-create."
 ---
 
@@ -115,6 +115,13 @@ After all issues are created, verify the hierarchy with `gh sub-issue list` on t
 - **Process top-down**: always create parent issues before children.
 
 See `references/usdm-issue-mapping.md` for the full mapping guide.
+
+## Before Finishing
+
+After creating issues, review each one from a reader's perspective:
+
+- **Self-contained?** Can someone understand this issue without access to the conversation or source document? If the issue body lacks context (reason, scope, acceptance criteria), add it before moving on.
+- **Source traceable?** Does every issue link back to its origin (USDM document, idea document, or conversation context)? A reader should be able to find the full context if they need it.
 
 ## Constraints
 

--- a/skills/planning/.claude-plugin/plugin.json
+++ b/skills/planning/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "planning",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Plan work by analyzing GitHub Issues, identifying dependencies, and defining work units.",
   "skills": ["."]
 }

--- a/skills/planning/SKILL.md
+++ b/skills/planning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: planning
-version: 0.1.0
+version: 0.2.0
 description: "Plan work by analyzing GitHub Issues, identifying dependencies, proposing execution order, and defining work units that map to feature branches. Outputs a persistent plan document. Use when: plan work, planning, prioritize issues, organize issues, create a plan, work breakdown, define work units, what should I work on first, /planning."
 ---
 
@@ -81,6 +81,13 @@ Work Unit 1: {description} (#{number}).
 ```
 
 After the plan is finalized, display the first work unit and its associated issues as the next action.
+
+## Before Finishing
+
+After generating the plan document, verify it stands on its own:
+
+- **Survives context loss?** If the conversation is lost and only the plan file remains, can someone resume work from it? Every work unit should reference concrete issue numbers, not just descriptions.
+- **Actionable?** Does each work unit have enough detail to create a branch and start working without re-reading the full issue thread?
 
 ## Constraints
 

--- a/skills/pull-request/.claude-plugin/plugin.json
+++ b/skills/pull-request/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pull-request",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Create GitHub pull requests with readiness checks, auto-drafted titles and descriptions, and remote push handling.",
   "skills": ["."]
 }

--- a/skills/pull-request/SKILL.md
+++ b/skills/pull-request/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pull-request
-version: 0.1.0
+version: 0.2.0
 description: "Create GitHub pull requests with readiness checks, auto-drafted titles and descriptions, and remote push handling. Use when: create PR, pull request, open PR, submit PR, create pull request, PR for review, push and PR, pull-request, /pull-request."
 ---
 
@@ -47,6 +47,13 @@ Generate a title and body from the commit history.
 ### Error Handling
 
 If PR creation fails, display the error message returned by `gh pr create`.
+
+## Before Finishing
+
+After creating the PR, review it from a reviewer's perspective:
+
+- **Understandable?** Can a reviewer who has no context about the conversation understand what this PR does and why, from the title and body alone?
+- **Complete?** Does the diff include all intended changes? Check `git status` for unstaged changes that may have been missed.
 
 ## Constraints
 

--- a/skills/skill-dev-workflow/.claude-plugin/plugin.json
+++ b/skills/skill-dev-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-dev-workflow",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Orchestrate the 9-step skill development lifecycle for the CaldiaWorks Skills repository.",
   "skills": ["."]
 }

--- a/skills/skill-dev-workflow/SKILL.md
+++ b/skills/skill-dev-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-dev-workflow
-version: 0.2.0
+version: 0.3.0
 description: "Orchestrate the 9-step skill development lifecycle for the CaldiaWorks Skills repository. Guides through ideation, issue creation, planning, branch creation, requirements definition, skill implementation, commit, pull request, and post-merge issue cleanup. Use when: skill development workflow, develop a skill end-to-end, skill-dev-workflow, /skill-dev-workflow, create and publish a skill."
 ---
 
@@ -125,6 +125,14 @@ Throughout the workflow, keep the plan document up to date:
 | Work unit begins | Status: `Pending` -> `In Progress` |
 | Branch created | Branch: `TBD` -> branch name |
 | PR merged or user confirms completion | Status: `In Progress` -> `Done` |
+
+## Before Finishing
+
+After the workflow completes (or when the user stops at any step), verify nothing is left behind:
+
+- **Open issues?** Are there sub-issues under the parent issue that should be closed? Step 9 handles this after merge, but if the workflow is interrupted earlier, flag any open issues to the user.
+- **Uncommitted changes?** Run `git status` to check for changes that were not included in the final commit.
+- **Plan up to date?** Does the plan document reflect the actual state of all work units (Status and Branch columns)?
 
 ## Constraints
 


### PR DESCRIPTION
## Summary

- Add "Before Finishing" verification sections to 5 workflow skills: `issue-create`, `planning`, `commit`, `pull-request`, `skill-dev-workflow`
- Each checklist prompts the agent to verify output quality from the consumer's perspective before completing

## Motivation

During the skill-dev-workflow implementation (#41), multiple gaps were discovered only after user feedback: issues lacking standalone context, plans not surviving context loss, orphaned sub-issues after merge, and incidental changes left uncommitted. These checklists encode those lessons directly into the skills.

## Changes by skill

| Skill | Checklist Focus |
|-------|----------------|
| `issue-create` | Self-containment, source traceability |
| `planning` | Context loss survival, actionability |
| `commit` | Remaining unstaged changes |
| `pull-request` | Reviewer comprehension, completeness |
| `skill-dev-workflow` | Residual issues, uncommitted changes, plan state |

Resolves #139