### PR TITLE
Remove per-skill .claude-plugin/plugin.json files

### DIFF
--- a/skills/branch-create/.claude-plugin/plugin.json
+++ b/skills/branch-create/.claude-plugin/plugin.json
@@ -1,6 +1,0 @@
-{
-  "name": "branch-create",
-  "version": "0.1.0",
-  "description": "Create feature branches linked to issues with consistent naming conventions.",
-  "skills": ["."]
-}

--- a/skills/commit/.claude-plugin/plugin.json
+++ b/skills/commit/.claude-plugin/plugin.json
@@ -1,6 +1,0 @@
-{
-  "name": "commit",
-  "version": "0.2.0",
-  "description": "Create focused git commits with change review, selective staging, and auto-drafted messages.",
-  "skills": ["."]
-}

--- a/skills/deep-research/.claude-plugin/plugin.json
+++ b/skills/deep-research/.claude-plugin/plugin.json
@@ -1,6 +1,0 @@
-{
-  "name": "deep-research",
-  "version": "0.2.0",
-  "description": "Conduct deep research through structured investigation design: question decomposition, plan approval, iterative exploration, and synthesis.",
-  "skills": ["."]
-}

--- a/skills/ears/.claude-plugin/plugin.json
+++ b/skills/ears/.claude-plugin/plugin.json
@@ -1,6 +1,0 @@
-{
-  "name": "ears",
-  "version": "0.1.0",
-  "description": "Write unambiguous specifications using EARS (Easy Approach to Requirements Syntax) patterns.",
-  "skills": ["."]
-}

--- a/skills/en-explainer/.claude-plugin/plugin.json
+++ b/skills/en-explainer/.claude-plugin/plugin.json
@@ -1,6 +1,0 @@
-{
-  "name": "en-explainer",
-  "version": "0.1.0",
-  "description": "Explain English technical documents and text in Japanese with contextual understanding.",
-  "skills": ["."]
-}

--- a/skills/ideation/.claude-plugin/plugin.json
+++ b/skills/ideation/.claude-plugin/plugin.json
@@ -1,6 +1,0 @@
-{
-  "name": "ideation",
-  "version": "0.1.0",
-  "description": "Turn rough ideas into structured, validated idea documents through collaborative dialogue.",
-  "skills": ["."]
-}

--- a/skills/issue-create/.claude-plugin/plugin.json
+++ b/skills/issue-create/.claude-plugin/plugin.json
@@ -1,6 +1,0 @@
-{
-  "name": "issue-create",
-  "version": "0.2.0",
-  "description": "Create GitHub Issues from user input or USDM requirements documents.",
-  "skills": ["."]
-}

--- a/skills/planning/.claude-plugin/plugin.json
+++ b/skills/planning/.claude-plugin/plugin.json
@@ -1,6 +1,0 @@
-{
-  "name": "planning",
-  "version": "0.2.0",
-  "description": "Plan work by analyzing GitHub Issues, identifying dependencies, and defining work units.",
-  "skills": ["."]
-}

--- a/skills/pull-request/.claude-plugin/plugin.json
+++ b/skills/pull-request/.claude-plugin/plugin.json
@@ -1,6 +1,0 @@
-{
-  "name": "pull-request",
-  "version": "0.2.0",
-  "description": "Create GitHub pull requests with readiness checks, auto-drafted titles and descriptions, and remote push handling.",
-  "skills": ["."]
-}

--- a/skills/requirements-docx/.claude-plugin/plugin.json
+++ b/skills/requirements-docx/.claude-plugin/plugin.json
@@ -1,6 +1,0 @@
-{
-  "name": "requirements-docx",
-  "version": "0.1.0",
-  "description": "Convert USDM/EARS requirements documents to professionally formatted Word documents.",
-  "skills": ["."]
-}

--- a/skills/skill-creator/.claude-plugin/plugin.json
+++ b/skills/skill-creator/.claude-plugin/plugin.json
@@ -1,6 +1,0 @@
-{
-  "name": "skill-creator",
-  "version": "0.1.2",
-  "description": "Create new skills, improve existing skills, and measure skill performance",
-  "skills": ["."]
-}

--- a/skills/skill-dev-workflow/.claude-plugin/plugin.json
+++ b/skills/skill-dev-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,0 @@
-{
-  "name": "skill-dev-workflow",
-  "version": "0.3.0",
-  "description": "Orchestrate the 9-step skill development lifecycle for the CaldiaWorks Skills repository.",
-  "skills": ["."]
-}

--- a/skills/skill-dev-workflow/SKILL.md
+++ b/skills/skill-dev-workflow/SKILL.md
@@ -83,12 +83,11 @@ Invoke the `skill-creator` skill.
 
 - Input: The USDM requirements document from Step 5
 - Output: Complete skill directory under `skills/<skill-name>/`
-- The skill must include `SKILL.md` with frontmatter and `.claude-plugin/plugin.json`
+- The skill must include `SKILL.md` with frontmatter
 
 After `skill-creator` completes:
-1. Verify the new skill's `.claude-plugin/plugin.json` exists.
-2. Add the skill path to both `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`.
-3. Bump the version in both manifest files to the same value.
+1. Add the skill path to both `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`.
+2. Bump the version in both manifest files to the same value.
 
 ### Step 7: Commit
 

--- a/skills/usdm/.claude-plugin/plugin.json
+++ b/skills/usdm/.claude-plugin/plugin.json
@@ -1,6 +1,0 @@
-{
-  "name": "usdm",
-  "version": "0.2.2",
-  "description": "Convert ambiguous user requests into structured USDM requirements documents.",
-  "skills": ["."]
-}


### PR DESCRIPTION
## Summary

- Delete per-skill `.claude-plugin/plugin.json` from all 13 skills under `skills/`
- Update `skill-dev-workflow/SKILL.md` to remove references to per-skill plugin.json verification

Per official Claude Code documentation, `plugin.json` belongs at the plugin root only.
Skills are auto-discovered from `SKILL.md` files. The root-level manifest already lists all skills.

Closes #141