### PR TITLE
Remove unnecessary confirmation steps from all skills

### DIFF
--- a/skills/branch-create/SKILL.md
+++ b/skills/branch-create/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: branch-create
-version: 0.1.0
+version: 0.2.0
 description: "Create feature branches linked to issues with consistent naming conventions. Generates branch names from issue numbers and descriptions, creates the branch, and checks it out. Use when: create branch, new branch, feature branch, branch for issue, start working on issue, branch-create, /branch-create."
 ---
 
@@ -12,11 +12,11 @@ Create a feature branch linked to an issue with a consistent naming convention. 
 
 ### Step 1: Collect Input
 
-Gather the issue number and a short description for the branch name.
+Gather the issue number for the branch name.
 
 1. Ask the user for the issue number. If provided as an argument, use it directly.
 2. If the issue number is provided, verify it exists with `gh issue view <number>`. If the issue does not exist, inform the user and stop.
-3. Ask for a short description (a few words summarizing the work). If the issue title is available, suggest a description derived from it.
+3. Derive a short description from the issue title automatically. Only ask the user for a description if the issue has no title.
 
 ### Step 2: Generate Branch Name
 
@@ -27,7 +27,6 @@ Generate the branch name following the project's naming convention.
    - Replace spaces and underscores with hyphens
    - Remove special characters
    - Collapse consecutive hyphens
-3. Present the generated branch name to the user for confirmation.
 
 If the project has a different convention documented (e.g., in CLAUDE.md or CONTRIBUTING.md), follow that convention instead.
 

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: commit
-version: 0.2.0
+version: 0.3.0
 description: "Create focused git commits with change review, selective staging, and auto-drafted messages. Use when: commit, git commit, save changes, commit my work, make a commit, stage and commit, review changes before committing. Also use when the user says /commit or asks to commit specific files."
 ---
 
@@ -22,25 +22,24 @@ Show the user what has changed so they can decide what to commit.
 
 ### Step 2: Stage Files
 
-Help the user select which files to include in this commit.
+Determine which files to include in this commit.
 
 - If the user has already specified files to commit, stage those files with `git add`.
-- If files are already staged and the user is satisfied, skip to Step 3.
-- If no files are staged, ask the user which files to stage. Present the list of changed files and let them choose.
+- If files are already staged, skip to Step 3.
+- If no files are staged, stage all changed files automatically. If the user specified particular files, stage only those.
 
 Stage specific files by name -- avoid `git add -A` or `git add .` as they can accidentally include sensitive files or unintended changes.
 
 ### Step 3: Commit
 
-Draft a commit message and create the commit after user approval.
+Draft a commit message and create the commit.
 
 1. Analyze the staged diff to draft a concise commit message:
    - First line: imperative summary under 72 characters
    - Blank line, then body with context if the change is non-trivial
    - Follow repository conventions if visible from recent `git log`
-2. Present the draft message to the user. They may approve, edit, or rewrite it.
-3. Create the commit with the approved message.
-4. Display the resulting commit hash and message.
+2. Create the commit with the drafted message.
+3. Display the resulting commit hash and message.
 
 Use a HEREDOC to pass the commit message to avoid shell escaping issues:
 ```bash

--- a/skills/issue-create/SKILL.md
+++ b/skills/issue-create/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-create
-version: 0.2.0
+version: 0.3.0
 description: "Create GitHub Issues from user input or USDM requirements documents. Standalone mode guides through title, body, and labels. USDM mode creates a hierarchy of issues from requirements with specifications in the issue body. Use when: create issue, new issue, GitHub issue, open issue, file issue, create issues from requirements, USDM to issues, issue-create, /issue-create."
 ---
 
@@ -25,16 +25,15 @@ Create a single issue through dialogue with the user.
 2. Accept an optional issue body describing the issue in detail.
 3. Accept optional labels for the issue.
 
-If the user provides all details upfront (e.g., "create an issue titled X about Y"), skip the interactive prompts and proceed to confirmation.
+If the user provides all details upfront (e.g., "create an issue titled X about Y"), skip the interactive prompts and proceed to creation.
 
-### Step 2: Confirm and Create
+### Step 2: Create Issue
 
-1. Present the issue details (title, body, labels) for user confirmation.
-2. On confirmation, create the issue:
+1. Create the issue immediately after collecting details:
    ```bash
    gh issue create --title "<title>" --label "<labels>" --body "<body>"
    ```
-3. Display the created issue number and URL.
+2. Display the created issue number and URL.
 
 ### Error Handling
 
@@ -59,7 +58,7 @@ Create a hierarchy of issues from a USDM requirements document. This mode is tri
    - Description
    - Child specifications (SPEC) belonging to that requirement
    - Parent requirement (if it is a sub-requirement)
-4. Present a summary of extracted requirements to the user for confirmation.
+4. Display a summary of the extraction: total number of requirements and the list of REQ IDs. Proceed to creation unless the user explicitly aborts.
 
 ### Step 2: Create Issues Top-Down
 
@@ -127,4 +126,4 @@ After creating issues, review each one from a reader's perspective:
 
 - Do not create issues outside the current repository.
 - Do not modify existing issues unless explicitly part of the USDM hierarchy creation.
-- Always confirm with the user before creating issues (in standalone mode) or before starting batch creation (in USDM mode).
+- In USDM mode, display the count and REQ IDs before batch creation. Proceed unless the user aborts.

--- a/skills/planning/SKILL.md
+++ b/skills/planning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: planning
-version: 0.2.0
+version: 0.3.0
 description: "Plan work by analyzing GitHub Issues, identifying dependencies, proposing execution order, and defining work units that map to feature branches. Outputs a persistent plan document. Use when: plan work, planning, prioritize issues, organize issues, create a plan, work breakdown, define work units, what should I work on first, /planning."
 ---
 
@@ -25,26 +25,24 @@ Works in any project with GitHub Issues.
 If reading issues from GitHub fails, display the error message and stop.
 If the specified parent issue has no sub-issues, inform the user there are no issues to plan.
 
-### Step 2: Identify Dependencies and Propose Order
+### Step 2: Identify Dependencies and Determine Order
 
 1. Analyze dependencies between issues based on:
    - Explicit references in issue bodies (e.g., "depends on #X", "blocked by #X")
    - Hierarchy: parent issues depend on child issues being resolved
    - Content: issues that produce artifacts needed by other issues
-2. Propose an execution order based on dependencies and priorities.
-3. Present the proposed order to the user for confirmation or modification.
+2. Determine an execution order based on dependencies and priorities.
 
-When proposing order, consider practical benefits: foundational tools first (e.g., a commit skill before other skills, so it can be used during their development).
+When determining order, consider practical benefits: foundational tools first (e.g., a commit skill before other skills, so it can be used during their development).
 
 ### Step 3: Define Work Units
 
-1. Propose groupings of related issues into work units. Each work unit:
-   - Corresponds to a single feature branch
-   - Contains issues that are closely related and make sense to implement together
-   - Has a clear, concise description
-2. Present the proposed work units to the user for confirmation or modification.
+Group related issues into work units. Each work unit:
+- Corresponds to a single feature branch
+- Contains issues that are closely related and make sense to implement together
+- Has a clear, concise description
 
-A work unit may contain a single issue or multiple related issues. The user decides the granularity.
+A work unit may contain a single issue or multiple related issues.
 
 ### Step 4: Output Plan Document
 

--- a/skills/pull-request/SKILL.md
+++ b/skills/pull-request/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pull-request
-version: 0.2.0
+version: 0.3.0
 description: "Create GitHub pull requests with readiness checks, auto-drafted titles and descriptions, and remote push handling. Use when: create PR, pull request, open PR, submit PR, create pull request, PR for review, push and PR, pull-request, /pull-request."
 ---
 
@@ -21,9 +21,9 @@ Verify the branch is ready for a pull request.
 3. If the current branch is not pushed to the remote, push it with tracking: `git push -u origin <branch>`.
 4. Check if a PR already exists for the current branch using `gh pr view`. If one exists, display the existing PR URL and ask the user whether to update it or abort.
 
-### Step 2: Draft PR Content
+### Step 2: Draft and Create PR
 
-Generate a title and body from the commit history.
+Generate a title and body from the commit history, then create the PR.
 
 1. Display the commit log between the base branch and HEAD: `git log --oneline <base>..HEAD`.
 2. Display the full diff: `git diff <base>...HEAD`.
@@ -31,18 +31,14 @@ Generate a title and body from the commit history.
    - Title: concise summary of the changes in imperative form
    - Body: structured summary with sections as appropriate
    - Follow repository conventions if visible from recent PRs
-4. Present the draft to the user. They may approve, edit, or rewrite it.
-
-### Step 3: Create PR
-
-1. Create the pull request on confirmation:
+4. Create the pull request:
    ```bash
    gh pr create --title "<title>" --body "$(cat <<'EOF'
    <body>
    EOF
    )"
    ```
-2. Display the PR number and URL.
+5. Display the PR number and URL.
 
 ### Error Handling
 

--- a/skills/skill-dev-workflow/SKILL.md
+++ b/skills/skill-dev-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-dev-workflow
-version: 0.3.0
+version: 0.4.0
 description: "Orchestrate the 9-step skill development lifecycle for the CaldiaWorks Skills repository. Guides through ideation, issue creation, planning, branch creation, requirements definition, skill implementation, commit, pull request, and post-merge issue cleanup. Use when: skill development workflow, develop a skill end-to-end, skill-dev-workflow, /skill-dev-workflow, create and publish a skill."
 ---
 
@@ -12,7 +12,7 @@ Orchestrate the full lifecycle of creating a skill for the CaldiaWorks marketpla
 
 Each invoked skill defines its own internal steps. **Every internal step of every invoked skill must be executed in order without exception.** Do not skip, merge, or silently omit any step -- even if the step seems trivial or the answer seems obvious.
 
-If a step requires user input or confirmation, ask. If a step produces output, present it. Violating this rule degrades quality and erodes user trust.
+Only ask the user for input that cannot be derived from available context (issue titles, document content, git history, etc.). If a step produces output, present it. Violating this rule degrades quality and erodes user trust.
 
 ## Partial Workflow Entry
 
@@ -29,7 +29,7 @@ Ask the user what artifacts they already have before starting.
 
 ## Workflow Steps
 
-Execute these 9 steps in order. After each step completes, ask the user whether to proceed to the next step.
+Execute these 9 steps in order. Proceed automatically from one step to the next.
 
 ### Step 1: Ideation
 


### PR DESCRIPTION
## Summary

- Remove or streamline user confirmation steps across 6 workflow skills to make default behavior fully automated
- Confirmation is now the exception (only when input cannot be derived from context), not the rule
- Bump versions for all affected skills

## Changes by Skill

| Skill | Version | Changes |
|-------|---------|---------|
| `commit` | 0.2.0 → 0.3.0 | Auto-stage all changed files; skip commit message approval |
| `branch-create` | 0.1.0 → 0.2.0 | Auto-derive description from issue title; skip branch name confirmation |
| `issue-create` | 0.2.0 → 0.3.0 | Create immediately in standalone mode; clarify USDM batch gate (show count + REQ IDs, proceed unless user aborts) |
| `pull-request` | 0.2.0 → 0.3.0 | Merge draft and create steps; skip draft approval |
| `planning` | 0.2.0 → 0.3.0 | Determine order and work units directly; skip user confirmation |
| `skill-dev-workflow` | 0.3.0 → 0.4.0 | Auto-proceed between steps; only ask for underivable input |

## Principle

> Default behavior is full automation. Confirmation is an exception, not a rule.

Resolves #143, resolves #142