### PR TITLE
Fix requirements-docx skill: broken reference, disposable script, missing pitfalls

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "CaldiaWorks plugin marketplace",
-    "version": "0.1.23",
+    "version": "0.1.24",
     "pluginRoot": "./"
   },
   "plugins": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "caldiaworks-marketplace",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "CaldiaWorks plugin marketplace",
   "skills": [
     "./skills/ears",

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ skills-lock.json
 .docs/
 *-workspace/
 **/evals/
+.DS_Store

--- a/skills/requirements-docx/SKILL.md
+++ b/skills/requirements-docx/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: requirements-docx
-version: 0.1.0
+version: 0.2.0
 description: "Convert USDM/EARS requirements documents from Markdown to professionally formatted Word (.docx) files for client submission. Generates cover pages, table of contents, headers/footers, and styled requirement hierarchies. Leverages the docx skill for Word file generation. Use when: export requirements to Word, requirements to docx, USDM to Word, convert requirements document, 要件書をWord出力, 要件定義書のdocx変換, Word形式で要件書を作成, 要件定義書をWordに変換."
 ---
 
@@ -56,17 +56,19 @@ Determine the document structure:
 
 Confirm the layout with the user before proceeding.
 
-### Step 3: Read docx-js Reference (MANDATORY)
+### Step 3: Read docx-js Pitfalls Guide (MANDATORY)
 
-**You MUST read the docx skill's `docx-js.md` reference file completely before generating any code.** This file contains critical syntax, formatting rules, and common pitfalls for the docx-js library.
+**You MUST read the docx-js pitfalls guide before generating any code.**
 
-Read the file at: `~/.agents/skills/docx/docx-js.md`
+Read the file at: `references/docx-js-pitfalls.md` in this skill's directory.
 
 ### Step 4: Generate and Execute docx-js Script
 
 1. Read the style definitions from `references/docx-style-definitions.md` in this skill's directory.
 2. Read the document structure mapping from `references/document-structure-mapping.md` in this skill's directory.
-3. Generate a JavaScript file in a temporary working directory within the project (e.g., `.tmp/`). Do not generate scripts in the project root. Delete the temporary directory after execution.
+3. Check if a conversion script already exists at `scripts/usdm-md-to-docx.js` in the project root.
+   - **IF exists**: Use the existing script. If the script fails or the output has issues, fix the script in-place rather than creating a new temporary script.
+   - **IF not exists**: Generate a JavaScript file at `scripts/usdm-md-to-docx.js` (permanent location). Do not generate scripts in `.tmp/` or delete them after execution.
 4. The generated script must implement:
    - Cover page with logo placeholder, title, metadata table, and confidentiality notice
    - Table of contents referencing Heading 1 through Heading 4
@@ -82,10 +84,16 @@ Read the file at: `~/.agents/skills/docx/docx-js.md`
 1. Save the .docx file in the current working directory.
 2. Name the file using the Document ID from metadata (e.g., `REQ-DOC-20260221-001-requirements-docx.docx`). If no Document ID is found, use the input filename with `.docx` extension.
 3. Report the output file path and size to the user.
-4. Suggest visual verification:
+4. Verify internal structure if layout issues are suspected:
    ```bash
-   soffice --headless --convert-to pdf <output.docx>
-   pdftoppm -jpeg -r 150 <output.pdf> page
+   # Check heading styles are applied (pStyle should appear)
+   unzip -p <output.docx> word/document.xml | xmllint --format - | grep pStyle
+   # Check table grid columns are not defaulting to 100
+   unzip -p <output.docx> word/document.xml | xmllint --format - | grep gridCol
+   ```
+5. Visual verification with LibreOffice is available only if `soffice` is installed:
+   ```bash
+   which soffice && soffice --headless --convert-to pdf <output.docx>
    ```
 
 ## Document Structure Mapping
@@ -186,6 +194,7 @@ Apply styles from `references/docx-style-definitions.md`. Key points:
 
 ## References
 
+- `references/docx-js-pitfalls.md` — Critical pitfalls when using docx-js (CRLF, heading styles)
 - `references/document-structure-mapping.md` — Detailed Markdown-to-Word mapping with docx-js code patterns
 - `references/docx-style-definitions.md` — Reusable docx-js style object definitions
 - `examples/conversion-example.md` — Before/after conversion walkthrough

--- a/skills/requirements-docx/references/docx-js-pitfalls.md
+++ b/skills/requirements-docx/references/docx-js-pitfalls.md
@@ -1,0 +1,51 @@
+# docx-js Known Pitfalls
+
+Supplementary guide for issues not covered in the other reference files.
+For table column widths, see `document-structure-mapping.md`.
+For ShadingType and font configuration, see `docx-style-definitions.md`.
+
+## 1. CRLF Line Ending Problem (Critical)
+
+**Symptom**: Headings, tables, and field patterns (Reason/Description) are not recognized
+from the input Markdown.
+
+**Cause**: When the Markdown file uses `\r\n` (Windows-style) line endings, `split('\n')`
+leaves trailing `\r` on each line. JavaScript regex `$` anchor does NOT match before `\r`
+(it only matches before `\n` or at the end of string). Additionally, `.` does not match `\r`.
+
+This causes all line-end-anchored patterns to fail:
+- `^(#{2,6})\s+(.+)$` — heading detection
+- `^\*\*Reason\*\*:\s*(.+)$` — Reason field extraction
+- `^\|(.+)\|$` — table row parsing
+
+**Fix**: Normalize line endings immediately after reading the file:
+```javascript
+const mdContent = fs.readFileSync(inputFile, 'utf-8').replace(/\r/g, '');
+```
+
+## 2. Why Heading Formatting Must Be on TextRun (not Paragraph Style)
+
+**Symptom**: Custom font sizes, colors, or bold settings defined in `paragraphStyles`
+with IDs like `"Heading1"` do not appear in the output document.
+
+**Cause**: docx-js has built-in default heading styles that take precedence over
+user-defined paragraph styles with the same ID. The built-in styles cannot be overridden.
+
+**Fix**: Apply formatting directly on the `TextRun` children of heading paragraphs.
+The heading level on the `Paragraph` ensures correct TOC integration, while the `TextRun`
+formatting controls the visual appearance:
+```javascript
+new Paragraph({
+  heading: HeadingLevel.HEADING_1,
+  children: [
+    new TextRun({
+      text: headingText,
+      bold: true,
+      size: 32,
+      color: "1F3864",
+      font: { ascii: "Arial", eastAsia: "Yu Gothic", hAnsi: "Arial" }
+    })
+  ]
+})
+```
+See `document-structure-mapping.md` for the complete heading pattern with `outlineLevel`.


### PR DESCRIPTION
Closes #147

## Summary

Fix 4 design issues in the `requirements-docx` skill discovered through actual usage:

- **Step 3**: Replace non-existent `~/.agents/skills/docx/docx-js.md` reference with skill-local `references/docx-js-pitfalls.md`
- **Step 4**: Change from disposable `.tmp/` script to permanent `scripts/usdm-md-to-docx.js` with reuse-first logic
- **Step 5**: Replace unavailable `soffice` with XML verification via `unzip`+`xmllint`, make LibreOffice conditional on availability
- **New reference**: `references/docx-js-pitfalls.md` covering CRLF line ending problem and heading style TextRun requirement

## Changes

| File | Change |
|------|--------|
| `skills/requirements-docx/SKILL.md` | Fix Steps 3-5, add reference entry, bump to v0.2.0 |
| `skills/requirements-docx/references/docx-js-pitfalls.md` | New: CRLF problem + heading style explanation |
| `.claude-plugin/plugin.json` | Bump to v0.1.24 |
| `.claude-plugin/marketplace.json` | Bump to v0.1.24 |

## Test plan

- [ ] Verify `references/docx-js-pitfalls.md` exists and is readable from the skill directory
- [ ] Verify Step 3 no longer references the non-existent file
- [ ] Verify Step 4 describes permanent script location
- [ ] Verify Step 5 uses `unzip`+`xmllint` and conditionally suggests `soffice`
- [ ] Run the skill end-to-end with a USDM document to confirm conversion works