### PR TITLE
Expand ideation Step 1 to investigate external references

### DIFF
--- a/skills/ideation/SKILL.md
+++ b/skills/ideation/SKILL.md
@@ -16,6 +16,21 @@ Complete these steps in order:
 
 ### Step 1: Explore Context
 
+Investigate **all information sources** referenced in the user's input before proceeding.
+
+#### 1a: External References
+
+Scan the user's input for external references — app names, technology names, URLs, specifications, standards, protocols, services, or documents. If any are found:
+
+- **URLs**: Fetch and read the linked content to understand scope, API surface, constraints, or specifications
+- **Named technologies/services**: Search for official documentation, capabilities, limitations, and integration patterns
+- **Existing apps or products**: Research their features, behavior, and design to understand what the user is referencing
+- **Standards/protocols**: Look up the specification to understand requirements and constraints
+
+Do NOT proceed to Step 2 until all external references are investigated. Misunderstanding an external reference propagates errors into every subsequent step.
+
+#### 1b: Project Context
+
 Review the current project to understand what already exists:
 
 - Check project files, documentation, and recent commits


### PR DESCRIPTION
## Summary

The ideation skill's Step 1: Explore Context was limited to project-internal investigation (files, commits, dependencies). When users referenced external information sources (apps, technologies, URLs, specifications), the skill proceeded without understanding them, producing inaccurate idea documents.

This PR splits Step 1 into two sub-steps:

- **1a: External References** — Scan user input for URLs, app names, technology names, specifications, and standards. Research each before proceeding to Step 2.
- **1b: Project Context** — Existing project-internal investigation (unchanged).

A gate is added: "Do NOT proceed to Step 2 until all external references are investigated."

## Test plan

- [ ] Invoke `/ideation` with input containing a URL — verify the URL is fetched and read before questions begin
- [ ] Invoke `/ideation` with a named technology — verify documentation is searched
- [ ] Invoke `/ideation` with no external references — verify it proceeds to 1b directly